### PR TITLE
Change bitmaps maximum size to uint64_t

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ bitmap
 #include <twiddle/bitmap/bitmap.h>
 
 int main(int argc, char* argv[]) {
-  const uint32_t nbits = 1024;
+  const uint64_t nbits = 1024;
   struct tw_bitmap* bitmap = tw_bitmap_new(nbits);
 
   assert(bitmap);
@@ -43,14 +43,14 @@ bitmap-rle
 
 int main(int argc, char* argv[]) {
   /** allocate a bitmap containing 2 billions bits */
-  const uint32_t nbits = 1UL << 31;
+  const uint64_t nbits = 1UL << 31;
   struct tw_bitmap_rle* bitmap = tw_bitmap_rle_new(nbits);
 
   assert(bitmap);
 
   /** fill 1 billion bits */
-  const uint32_t start = 0UL;
-  const uint32_t end = 1UL << 30;
+  const uint64_t start = 0UL;
+  const uint64_t end = 1UL << 30;
   tw_bitmap_rle_set_range(bitmap, start, end);
 
   /**
@@ -80,8 +80,8 @@ bloomfilter
 #include <twiddle/bloomfilter/bloomfilter.h>
 
 int main(int argc, char *argv[]) {
-  const uint32_t nbits = 1024;
-  const uint32_t k = 7;
+  const uint64_t nbits = 1024;
+  const uint16_t k = 7;
   struct tw_bloomfilter *bf = tw_bloomfilter_new(nbits, k);
   assert(bf);
 

--- a/include/twiddle/bitmap/bitmap.h
+++ b/include/twiddle/bitmap/bitmap.h
@@ -14,11 +14,15 @@
 #define TW_BYTES_PER_BITMAP sizeof(bitmap_t)
 #define TW_BITS_PER_BITMAP  (TW_BYTES_PER_BITMAP * TW_BITS_IN_WORD)
 
+
 /**
  * Computes the number of required `bitmap_t` to hold `nbits` bits.
  */
 #define TW_BITMAP_PER_BITS(nbits)   TW_DIV_ROUND_UP(nbits, TW_BITS_PER_BITMAP)
 #define TW_BITMAP_POS(nbits)        (nbits / TW_BITS_PER_BITMAP)
+
+#define TW_BITMAP_MAX_BITS (1UL << 48)
+#define TW_BITMAP_MAX_POS  (TW_BITMAP_MAX_BITS - 1)
 
 /**
  * struct tw_bitmap_info - bitmap miscellaneous information
@@ -26,17 +30,17 @@
  * @count: number of active bits
  */
 struct tw_bitmap_info {
-  uint32_t size;
-  uint32_t count;
+  uint64_t size;
+  uint64_t count;
 };
 
-#define tw_bitmap_info_init(nbits) (struct tw_bitmap_info) {.size = nbits, .count = 0U}
+#define tw_bitmap_info_init(nbits) (struct tw_bitmap_info) {.size = nbits, .count = 0UL}
 #define tw_bitmap_info_copy(src, dst) \
   dst = (struct tw_bitmap_info) {.size = src.size, .count = src.count}
 #define tw_bitmap_info_count(info)   (info.count)
 #define tw_bitmap_info_size(info)    (info.size)
 #define tw_bitmap_info_density(info) (info.count / (1.0 * info.size))
-#define tw_bitmap_info_empty(info)   (info.count == 0U)
+#define tw_bitmap_info_empty(info)   (info.count == 0UL)
 #define tw_bitmap_info_full(info)    (info.count == info.size)
 
 /**
@@ -66,7 +70,7 @@ struct tw_bitmap {
  *         allocated `struct tw_bitmap`.
  */
 struct tw_bitmap *
-tw_bitmap_new(uint32_t size);
+tw_bitmap_new(uint64_t size);
 
 /**
  * tw_bitmap_free() - free a bitmap
@@ -104,7 +108,7 @@ tw_bitmap_clone(const struct tw_bitmap *bitmap);
  * @pos:    position of the bit to set
  */
 void
-tw_bitmap_set(struct tw_bitmap *bitmap, uint32_t pos);
+tw_bitmap_set(struct tw_bitmap *bitmap, uint64_t pos);
 
 /**
  * tw_bitmap_clear() - clear position in bitmap
@@ -112,7 +116,7 @@ tw_bitmap_set(struct tw_bitmap *bitmap, uint32_t pos);
  * @pos:    position of the bit to clear
  */
 void
-tw_bitmap_clear(struct tw_bitmap *bitmap, uint32_t pos);
+tw_bitmap_clear(struct tw_bitmap *bitmap, uint64_t pos);
 
 /**
  * tw_bitmap_test() - test postition in bitmap
@@ -122,7 +126,7 @@ tw_bitmap_clear(struct tw_bitmap *bitmap, uint32_t pos);
  * Return: value pos in the bitmap
  */
 bool
-tw_bitmap_test(const struct tw_bitmap *bitmap, uint32_t pos);
+tw_bitmap_test(const struct tw_bitmap *bitmap, uint64_t pos);
 
 /**
  * tw_bitmap_test_and_set() - test position in bitmap and set afterward
@@ -132,7 +136,7 @@ tw_bitmap_test(const struct tw_bitmap *bitmap, uint32_t pos);
  * Return: value of the position in the bitmap before setting it.
  */
 bool
-tw_bitmap_test_and_set(struct tw_bitmap *bitmap, uint32_t pos);
+tw_bitmap_test_and_set(struct tw_bitmap *bitmap, uint64_t pos);
 
 /**
  * tw_bitmap_test_and_clear() - test position in bitmap and clear afterward
@@ -142,7 +146,7 @@ tw_bitmap_test_and_set(struct tw_bitmap *bitmap, uint32_t pos);
  * Return: value of the position in the bitmap before clearing it.
  */
 bool
-tw_bitmap_test_and_clear(struct tw_bitmap *bitmap, uint32_t pos);
+tw_bitmap_test_and_clear(struct tw_bitmap *bitmap, uint64_t pos);
 
 /**
  * tw_bitmap_empty() - verify if bitmap is empty
@@ -168,7 +172,7 @@ tw_bitmap_full(const struct tw_bitmap *bitmap);
  *
  * Return: number of active bits
  */
-uint32_t
+uint64_t
 tw_bitmap_count(const struct tw_bitmap *bitmap);
 
 /**

--- a/include/twiddle/bitmap/bitmap_rle.h
+++ b/include/twiddle/bitmap/bitmap_rle.h
@@ -12,17 +12,17 @@
  */
 
 struct tw_bitmap_rle_word {
-  uint32_t pos;
-  uint32_t count;
+  uint64_t pos;
+  uint64_t count;
 };
 
 #define TW_BITMAP_RLE_WORD_PER_CACHELINE \
   (TW_CACHELINE / sizeof(struct tw_bitmap_rle_word))
 
 #define tw_bitmap_rle_word_zero \
-  (struct tw_bitmap_rle_word) {.pos = 0, .count = 0}
+  (struct tw_bitmap_rle_word) {.pos = 0UL, .count = 0UL}
 #define tw_bitmap_rle_word_full(nbits) \
-  (struct tw_bitmap_rle_word) {.pos = 0, .count = nbits}
+  (struct tw_bitmap_rle_word) {.pos = 0UL, .count = nbits}
 #define tw_bitmap_rle_word_equal(a, b) \
   (a.pos == b.pos && a.count == b.count)
 #define tw_bitmap_rle_word_end(a) (a.pos + a.count - 1)
@@ -41,9 +41,9 @@ struct tw_bitmap_rle_word {
 struct tw_bitmap_rle {
   struct tw_bitmap_info info;
 
-  uint32_t last_pos;
-  uint32_t last_word_idx;
-  uint32_t alloc_word;
+  uint64_t last_pos;
+  uint64_t last_word_idx;
+  uint64_t alloc_word;
 
   struct tw_bitmap_rle_word *data;
 };
@@ -58,7 +58,7 @@ struct tw_bitmap_rle {
  *         allocated `struct tw_bitmap_rle`.
  */
 struct tw_bitmap_rle *
-tw_bitmap_rle_new(uint32_t nbits);
+tw_bitmap_rle_new(uint64_t nbits);
 
 /**
  * tw_bitmap_rle_free() - free a bitmap
@@ -99,7 +99,7 @@ tw_bitmap_rle_clone(const struct tw_bitmap_rle *bitmap);
  * argument.
  */
 void
-tw_bitmap_rle_set(struct tw_bitmap_rle *bitmap, uint32_t pos);
+tw_bitmap_rle_set(struct tw_bitmap_rle *bitmap, uint64_t pos);
 
 /**
  * tw_bitmap_rle_set_word() - set bitmap_rle_word in bitmap
@@ -123,8 +123,8 @@ tw_bitmap_rle_set_word(struct tw_bitmap_rle *bitmap,
  */
 void
 tw_bitmap_rle_set_range(struct tw_bitmap_rle *bitmap,
-                        uint32_t start,
-                        uint32_t end);
+                        uint64_t start,
+                        uint64_t end);
 
 /**
  * tw_bitmap_rle_test() - test postition in bitmap
@@ -134,7 +134,7 @@ tw_bitmap_rle_set_range(struct tw_bitmap_rle *bitmap,
  * Return: value of pos in the bitmap
  */
 bool
-tw_bitmap_rle_test(const struct tw_bitmap_rle *bitmap, uint32_t pos);
+tw_bitmap_rle_test(const struct tw_bitmap_rle *bitmap, uint64_t pos);
 
 /**
  * tw_bitmap_rle_empty() - verify if bitmap is empty
@@ -160,7 +160,7 @@ tw_bitmap_rle_full(const struct tw_bitmap_rle *bitmap);
  *
  * Return: number of active bits
  */
-uint32_t
+uint64_t
 tw_bitmap_rle_count(const struct tw_bitmap_rle *bitmap);
 
 /**

--- a/include/twiddle/bloomfilter/bloomfilter.h
+++ b/include/twiddle/bloomfilter/bloomfilter.h
@@ -12,17 +12,16 @@
  * @k:    number of hash functions used
  */
 struct tw_bloomfilter_info {
-  uint32_t size;
-  uint32_t k;
   uint64_t hash_seed;
+  uint16_t k;
 };
 
-#define tw_bloomfilter_info_init(s,k,h) \
-  (struct tw_bloomfilter_info) {.size = s, .k = k, .hash_seed = h}
+#define tw_bloomfilter_info_init(k,h) \
+  (struct tw_bloomfilter_info) {.k = k, .hash_seed = h}
 #define tw_bloomfilter_info_copy(src, dst) \
-  dst = (struct tw_bloomfilter_info) {.size = src.size, .k = src.k, .hash_seed = src.hash_seed}
+  dst = (struct tw_bloomfilter_info) {.k = src.k, .hash_seed = src.hash_seed}
 #define tw_bloomfilter_info_equal(src, dst) \
-  (src.size == dst.size && src.k == dst.k && src.hash_seed == dst.hash_seed)
+  (src.k == dst.k && src.hash_seed == dst.hash_seed)
 
 #define TW_BF_DEFAULT_SEED 3781869495ULL
 
@@ -49,7 +48,7 @@ struct tw_bloomfilter {
  *         allocated `struct tw_bloomfilter`.
  */
 struct tw_bloomfilter *
-tw_bloomfilter_new(uint32_t size, uint32_t k);
+tw_bloomfilter_new(uint64_t size, uint16_t k);
 
 /**
  * tw_bloomfilter_free() - free a bloomfilter
@@ -127,7 +126,7 @@ tw_bloomfilter_full(const struct tw_bloomfilter *bf);
  *
  * Return: number of active bits
  */
-uint32_t
+uint64_t
 tw_bloomfilter_count(const struct tw_bloomfilter *bf);
 
 /**

--- a/python/twiddle/c.py
+++ b/python/twiddle/c.py
@@ -18,7 +18,7 @@ libtwiddle = CDLL(find_twiddle_so())
 
 # BITMAP
 
-libtwiddle.tw_bitmap_new.argtypes = [c_uint]
+libtwiddle.tw_bitmap_new.argtypes = [c_ulong]
 libtwiddle.tw_bitmap_new.restype  = c_void_p
 
 libtwiddle.tw_bitmap_free.argtypes = [c_void_p]
@@ -30,16 +30,16 @@ libtwiddle.tw_bitmap_copy.restype  = c_void_p
 libtwiddle.tw_bitmap_clone.argtypes = [c_void_p]
 libtwiddle.tw_bitmap_clone.restype  = c_void_p
 
-libtwiddle.tw_bitmap_set.argtypes = [c_void_p, c_uint]
+libtwiddle.tw_bitmap_set.argtypes = [c_void_p, c_ulong]
 libtwiddle.tw_bitmap_set.restype  = None
 
-libtwiddle.tw_bitmap_clear.argtypes = [c_void_p, c_uint]
+libtwiddle.tw_bitmap_clear.argtypes = [c_void_p, c_ulong]
 libtwiddle.tw_bitmap_clear.restype  = None
 
-libtwiddle.tw_bitmap_test.argtypes = [c_void_p, c_uint]
+libtwiddle.tw_bitmap_test.argtypes = [c_void_p, c_ulong]
 libtwiddle.tw_bitmap_test.restype  = c_bool
 
-libtwiddle.tw_bitmap_test_and_clear.argtypes = [c_void_p, c_uint]
+libtwiddle.tw_bitmap_test_and_clear.argtypes = [c_void_p, c_ulong]
 libtwiddle.tw_bitmap_test_and_clear.restype  = c_bool
 
 libtwiddle.tw_bitmap_empty.argtypes = [c_void_p]
@@ -49,7 +49,7 @@ libtwiddle.tw_bitmap_full.argtypes = [c_void_p]
 libtwiddle.tw_bitmap_full.restype  = c_bool
 
 libtwiddle.tw_bitmap_count.argtypes = [c_void_p]
-libtwiddle.tw_bitmap_count.restype  = c_uint
+libtwiddle.tw_bitmap_count.restype  = c_ulong
 
 libtwiddle.tw_bitmap_density.argtypes = [c_void_p]
 libtwiddle.tw_bitmap_density.restype  = c_float
@@ -83,7 +83,7 @@ libtwiddle.tw_bitmap_xor.restype  = c_void_p
 
 # BITMAP_RLE
 
-libtwiddle.tw_bitmap_rle_new.argtypes = [c_uint]
+libtwiddle.tw_bitmap_rle_new.argtypes = [c_ulong]
 libtwiddle.tw_bitmap_rle_new.restype  = c_void_p
 
 libtwiddle.tw_bitmap_rle_free.argtypes = [c_void_p]
@@ -95,10 +95,10 @@ libtwiddle.tw_bitmap_rle_copy.restype  = c_void_p
 libtwiddle.tw_bitmap_rle_clone.argtypes = [c_void_p]
 libtwiddle.tw_bitmap_rle_clone.restype  = c_void_p
 
-libtwiddle.tw_bitmap_rle_set.argtypes = [c_void_p, c_uint]
+libtwiddle.tw_bitmap_rle_set.argtypes = [c_void_p, c_ulong]
 libtwiddle.tw_bitmap_rle_set.restype  = None
 
-libtwiddle.tw_bitmap_rle_test.argtypes = [c_void_p, c_uint]
+libtwiddle.tw_bitmap_rle_test.argtypes = [c_void_p, c_ulong]
 libtwiddle.tw_bitmap_rle_test.restype  = c_bool
 
 libtwiddle.tw_bitmap_rle_empty.argtypes = [c_void_p]
@@ -108,7 +108,7 @@ libtwiddle.tw_bitmap_rle_full.argtypes = [c_void_p]
 libtwiddle.tw_bitmap_rle_full.restype  = c_bool
 
 libtwiddle.tw_bitmap_rle_count.argtypes = [c_void_p]
-libtwiddle.tw_bitmap_rle_count.restype  = c_uint
+libtwiddle.tw_bitmap_rle_count.restype  = c_ulong
 
 libtwiddle.tw_bitmap_rle_density.argtypes = [c_void_p]
 libtwiddle.tw_bitmap_rle_density.restype  = c_float
@@ -139,7 +139,7 @@ libtwiddle.tw_bitmap_rle_intersection.restype  = c_void_p
 
 # BLOOMFILTER
 
-libtwiddle.tw_bloomfilter_new.argtypes = [c_uint, c_uint]
+libtwiddle.tw_bloomfilter_new.argtypes = [c_ulong, c_ushort]
 libtwiddle.tw_bloomfilter_new.restype  = c_void_p
 
 libtwiddle.tw_bloomfilter_free.argtypes = [c_void_p]
@@ -151,10 +151,10 @@ libtwiddle.tw_bloomfilter_copy.restype  = c_void_p
 libtwiddle.tw_bloomfilter_clone.argtypes = [c_void_p]
 libtwiddle.tw_bloomfilter_clone.restype  = c_void_p
 
-libtwiddle.tw_bloomfilter_set.argtypes = [c_void_p, c_uint, c_void_p]
+libtwiddle.tw_bloomfilter_set.argtypes = [c_void_p, c_ulong, c_void_p]
 libtwiddle.tw_bloomfilter_set.restype  = None
 
-libtwiddle.tw_bloomfilter_test.argtypes = [c_void_p, c_uint, c_void_p]
+libtwiddle.tw_bloomfilter_test.argtypes = [c_void_p, c_ulong, c_void_p]
 libtwiddle.tw_bloomfilter_test.restype  = c_bool
 
 libtwiddle.tw_bloomfilter_empty.argtypes = [c_void_p]
@@ -164,7 +164,7 @@ libtwiddle.tw_bloomfilter_full.argtypes = [c_void_p]
 libtwiddle.tw_bloomfilter_full.restype  = c_bool
 
 libtwiddle.tw_bloomfilter_count.argtypes = [c_void_p]
-libtwiddle.tw_bloomfilter_count.restype  = c_uint
+libtwiddle.tw_bloomfilter_count.restype  = c_ulong
 
 libtwiddle.tw_bloomfilter_density.argtypes = [c_void_p]
 libtwiddle.tw_bloomfilter_density.restype  = c_float

--- a/src/twiddle/bitmap/bitmap.c
+++ b/src/twiddle/bitmap/bitmap.c
@@ -17,8 +17,9 @@ tw_bitmap_clear_extra_bits(struct tw_bitmap* bitmap)
 }
 
 struct tw_bitmap *
-tw_bitmap_new(uint32_t size)
+tw_bitmap_new(uint64_t size)
 {
+  assert(0 < size && size <= TW_BITMAP_MAX_BITS);
   const size_t alloc_size = sizeof(struct tw_bitmap_info) +
                             TW_BITMAP_PER_BITS(size) * TW_BYTES_PER_BITMAP;
   struct tw_bitmap *bitmap = calloc(1, alloc_size);
@@ -75,29 +76,29 @@ tw_bitmap_clone(const struct tw_bitmap *bitmap)
 }
 
 void __always_inline
-tw_bitmap_set(struct tw_bitmap *bitmap, uint32_t pos)
+tw_bitmap_set(struct tw_bitmap *bitmap, uint64_t pos)
 {
   tw_bitmap_test_and_set(bitmap, pos);
 }
 
 void __always_inline
-tw_bitmap_clear(struct tw_bitmap *bitmap, uint32_t pos)
+tw_bitmap_clear(struct tw_bitmap *bitmap, uint64_t pos)
 {
   tw_bitmap_test_and_clear(bitmap, pos);
 }
 
 bool
-tw_bitmap_test(const struct tw_bitmap *bitmap, uint32_t pos)
+tw_bitmap_test(const struct tw_bitmap *bitmap, uint64_t pos)
 {
   assert(bitmap && pos < bitmap->info.size);
   return variable_test_bit(pos % 64, &(bitmap->data[TW_BITMAP_POS(pos)]));
 }
 
 bool
-tw_bitmap_test_and_set(struct tw_bitmap *bitmap, uint32_t pos)
+tw_bitmap_test_and_set(struct tw_bitmap *bitmap, uint64_t pos)
 {
   assert(bitmap && pos < bitmap->info.size);
-  assert(bitmap->info.count < UINT32_MAX);
+  assert(bitmap->info.count < UINT64_MAX);
 
   bool val = __test_and_set_bit(pos % 64, &(bitmap->data[TW_BITMAP_POS(pos)]));
   if (!val) {
@@ -108,7 +109,7 @@ tw_bitmap_test_and_set(struct tw_bitmap *bitmap, uint32_t pos)
 }
 
 bool
-tw_bitmap_test_and_clear(struct tw_bitmap *bitmap, uint32_t pos)
+tw_bitmap_test_and_clear(struct tw_bitmap *bitmap, uint64_t pos)
 {
   assert(bitmap && pos < bitmap->info.size);
 
@@ -134,7 +135,7 @@ tw_bitmap_full(const struct tw_bitmap *bitmap)
   return tw_bitmap_info_full(bitmap->info);
 }
 
-uint32_t
+uint64_t
 tw_bitmap_count(const struct tw_bitmap *bitmap)
 {
   assert(bitmap);
@@ -267,7 +268,7 @@ tw_bitmap_union(const struct tw_bitmap *src, struct tw_bitmap *dst)
     return NULL;
   }
 
-  uint32_t count = 0;
+  uint64_t count = 0;
   for (size_t i = 0; i < TW_BITMAP_PER_BITS(src->info.size); ++i) {
     dst->data[i] |= src->data[i];
     count += tw_popcountl(dst->data[i]);
@@ -287,7 +288,7 @@ tw_bitmap_intersection(const struct tw_bitmap *src, struct tw_bitmap *dst)
     return NULL;
   }
 
-  uint32_t count = 0;
+  uint64_t count = 0;
   for (size_t i = 0; i < TW_BITMAP_PER_BITS(src->info.size); ++i) {
     dst->data[i] &= src->data[i];
     count += tw_popcountl(dst->data[i]);
@@ -307,7 +308,7 @@ tw_bitmap_xor(const struct tw_bitmap *src, struct tw_bitmap *dst)
     return NULL;
   }
 
-  uint32_t count = 0;
+  uint64_t count = 0;
   for (size_t i = 0; i < TW_BITMAP_PER_BITS(src->info.size); ++i) {
     dst->data[i] ^= src->data[i];
     count += tw_popcountl(dst->data[i]);

--- a/tests/examples/example-bitmap-rle.c
+++ b/tests/examples/example-bitmap-rle.c
@@ -3,14 +3,14 @@
 
 int main(int argc, char* argv[]) {
   /** allocate a bitmap containing 2 billions bits */
-  const uint32_t nbits = 1UL << 31;
+  const uint64_t nbits = 1UL << 31;
   struct tw_bitmap_rle* bitmap = tw_bitmap_rle_new(nbits);
 
   assert(bitmap);
 
   /** fill 1 billion bits */
-  const uint32_t start = 0UL;
-  const uint32_t end = 1UL << 30;
+  const uint64_t start = 0UL;
+  const uint64_t end = 1UL << 30;
   tw_bitmap_rle_set_range(bitmap, start, end);
 
   /**

--- a/tests/examples/example-bitmap.c
+++ b/tests/examples/example-bitmap.c
@@ -2,7 +2,7 @@
 #include <twiddle/bitmap/bitmap.h>
 
 int main(int argc, char* argv[]) {
-  const uint32_t nbits = 1024;
+  const uint64_t nbits = 1024;
   struct tw_bitmap* bitmap = tw_bitmap_new(nbits);
 
   assert(bitmap);

--- a/tests/examples/example-bloomfilter.c
+++ b/tests/examples/example-bloomfilter.c
@@ -4,8 +4,8 @@
 #include <twiddle/bloomfilter/bloomfilter.h>
 
 int main(int argc, char *argv[]) {
-  const uint32_t nbits = 1024;
-  const uint32_t k = 7;
+  const uint64_t nbits = 1024;
+  const uint16_t k = 7;
   struct tw_bloomfilter *bf = tw_bloomfilter_new(nbits, k);
   assert(bf);
 

--- a/tests/test-bitmap.c
+++ b/tests/test-bitmap.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <signal.h>
 
 #include <check.h>
 
@@ -263,11 +264,28 @@ START_TEST(test_bitmap_set_operations)
 }
 END_TEST
 
+START_TEST(test_bitmap_new_assert_0)
+{
+  struct tw_bitmap *b = tw_bitmap_new(0);
+
+  tw_bitmap_count(b);
+}
+END_TEST
+
+START_TEST(test_bitmap_new_assert_max_p1)
+{
+  struct tw_bitmap *b = tw_bitmap_new(TW_BITMAP_MAX_BITS + 1);
+
+  tw_bitmap_count(b);
+}
+END_TEST
+
 int run_tests() {
   int number_failed;
 
   Suite  *s = suite_create("bitmap");
   SRunner *runner = srunner_create(s);
+
   TCase *tc = tcase_create("basic");
   tcase_add_test(tc, test_bitmap_basic);
   tcase_add_test(tc, test_bitmap_report);
@@ -276,6 +294,12 @@ int run_tests() {
   tcase_add_test(tc, test_bitmap_find_first);
   tcase_add_test(tc, test_bitmap_set_operations);
   suite_add_tcase(s, tc);
+
+  TCase *ta = tcase_create("assert");
+  tcase_add_test_raise_signal(ta, test_bitmap_new_assert_0, SIGABRT);
+  tcase_add_test_raise_signal(ta, test_bitmap_new_assert_max_p1, SIGABRT);
+  suite_add_tcase(s, ta);
+
   srunner_run_all(runner, CK_NORMAL);
   number_failed = srunner_ntests_failed(runner);
   srunner_free(runner);


### PR DESCRIPTION
This feature affects `tw_bitmap`, `tw_bitmap_rle` and `tw_bloomfilter`. The goal is to allow bitmaps bigger than 512mb.