### PR TITLE
Implements bf-uniq example

### DIFF
--- a/include/twiddle/bloomfilter/bloomfilter.h
+++ b/include/twiddle/bloomfilter/bloomfilter.h
@@ -1,6 +1,7 @@
 #ifndef TWIDDLE_BLOOMFILTER_H
 #define TWIDDLE_BLOOMFILTER_H
 
+#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -24,6 +25,11 @@ struct tw_bloomfilter_info {
   (src.k == dst.k && src.hash_seed == dst.hash_seed)
 
 #define TW_BF_DEFAULT_SEED 3781869495ULL
+
+#define TW_LOG_2 0.6931471805599453
+
+#define tw_bloomfilter_optimal_m(n, p) (-n * log(p) / (TW_LOG_2 * TW_LOG_2))
+#define tw_bloomfilter_optimal_k(n, m) (m / n * TW_LOG_2)
 
 /**
  * struct tw_bloomfilter - bloomfilter

--- a/src/twiddle/bitmap/bitmap.c
+++ b/src/twiddle/bitmap/bitmap.c
@@ -23,6 +23,11 @@ tw_bitmap_new(uint64_t size)
   const size_t alloc_size = sizeof(struct tw_bitmap_info) +
                             TW_BITMAP_PER_BITS(size) * TW_BYTES_PER_BITMAP;
   struct tw_bitmap *bitmap = calloc(1, alloc_size);
+
+  if (!bitmap) {
+    return NULL;
+  }
+
   bitmap->info = tw_bitmap_info_init(size);
   return bitmap;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,3 +19,5 @@ add_c_test(test-bloomfilter)
 add_c_test(test-hyperloglog)
 
 add_subdirectory(examples)
+
+

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -16,3 +16,25 @@ add_c_test(example-bitmap)
 add_c_test(example-bitmap-rle)
 add_c_test(example-bloomfilter)
 add_c_test(example-hyperloglog)
+
+add_c_example(bf-uniq)
+
+find_package(PythonInterp)
+
+if (PYTHON_EXECUTABLE)
+    file(GLOB_RECURSE TESTS "${CMAKE_CURRENT_SOURCE_DIR}/*.t")
+    foreach(TEST ${TESTS})
+        get_filename_component(TEST_NAME "${TEST}" NAME_WE)
+        add_test(
+            ${TEST_NAME}
+            ${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}
+            ${CMAKE_BINARY_DIR}/../tools/cram/ccram
+                --python ${PYTHON_EXECUTABLE}
+                --root  ${CMAKE_CURRENT_SOURCE_DIR}
+                --build ${CMAKE_BINARY_DIR}/tests/examples
+                --tests ${TEST}
+        )
+    endforeach(TEST)
+else (PYTHON_EXECUTABLE)
+    message(WARNING "Unable to find Python; skipping cram tests.")
+endif (PYTHON_EXECUTABLE)

--- a/tests/examples/bf-uniq.c
+++ b/tests/examples/bf-uniq.c
@@ -1,0 +1,110 @@
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <twiddle/bloomfilter/bloomfilter.h>
+
+static struct option long_options[] = {
+  {"probability", required_argument, 0, 'p'},
+  {"count"      , required_argument, 0, 'n'},
+  {0            , 0                , 0,  0 }
+};
+
+
+int parse_probability(const char *opt, float *p) {
+  const float parsed_p = strtof(optarg, NULL);
+  if (!(0 < parsed_p && parsed_p <= 1)) {
+    return -1;
+  }
+
+  *p = parsed_p;
+
+  return 0;
+}
+
+
+int parse_count(const char *opt, int64_t *n) {
+  const int64_t parsed_n = strtoll(optarg, NULL, 10);
+  if (!(0 <= parsed_n && parsed_n <= TW_BITMAP_MAX_BITS)) {
+    return -1;
+  }
+
+  *n = parsed_n;
+
+  return 0;
+}
+
+static
+int
+parse_arguments(int argc, char **argv, int64_t *n, float *p)
+{
+  int c = 0;
+  int ret = 0;
+
+  while (1) {
+    int option_index = 0;
+
+    c = getopt_long(argc, argv, "n:p:", long_options, &option_index);
+    if (c == -1)
+        break;
+
+    switch (c) {
+    case 'p':
+      if ((ret = parse_probability(optarg, p)) != 0) {
+        return ret;
+      }
+      break;
+    case 'n':
+      if ((ret = parse_count(optarg, n)) != 0) {
+        return ret;
+      }
+      break;
+    default:
+      printf("?? getopt returned character code 0%o ??\n", c);
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+int
+main(int argc, char *argv[])
+{
+  int64_t n = 1000000;
+  float   p = 0.0001;
+
+  if (parse_arguments(argc, argv, &n, &p) != 0) {
+    exit(-1);
+  }
+
+  const uint64_t m = tw_bloomfilter_optimal_m(n, p);
+  const uint16_t k = tw_bloomfilter_optimal_k(n, m);
+
+  /* parse options */
+
+  struct tw_bloomfilter *bf = tw_bloomfilter_new(m, k);
+
+  if (!bf) {
+    exit(1);
+  }
+
+  char   *line = NULL;
+  size_t   len = 0;
+  ssize_t read = 0;
+
+  while ((read = getline(&line, &len, stdin)) != -1) {
+
+    if (!tw_bloomfilter_test(bf, len, line)) {
+      printf("%s", line);
+      tw_bloomfilter_set(bf, len, line);
+    }
+
+  }
+
+
+  tw_bloomfilter_free(bf);
+
+  return 0;
+}

--- a/tests/examples/bf-uniq.t
+++ b/tests/examples/bf-uniq.t
@@ -1,0 +1,4 @@
+  $ echo "a\na\nb\nc\nb" | bf-uniq
+  a
+  b
+  c

--- a/tools/cmake/FindCTargets.cmake
+++ b/tools/cmake/FindCTargets.cmake
@@ -213,3 +213,15 @@ function(add_c_test TEST_NAME)
     )
     add_test(${TEST_NAME} ${TEST_NAME})
 endfunction(add_c_test)
+
+function(add_c_example EXAMPLE_NAME)
+    get_property(ALL_LOCAL_LIBRARIES GLOBAL PROPERTY ALL_LOCAL_LIBRARIES)
+    add_c_executable(
+        ${EXAMPLE_NAME}
+        SKIP_INSTALL
+        OUTPUT_NAME ${EXAMPLE_NAME}
+        SOURCES ${EXAMPLE_NAME}.c
+        LIBRARIES check m
+        LOCAL_LIBRARIES ${ALL_LOCAL_LIBRARIES}
+    )
+endfunction(add_c_example)

--- a/tools/cram/ccram
+++ b/tools/cram/ccram
@@ -16,6 +16,14 @@ else
     ROOT=$(dirname $PWD)
 fi
 
+if [ "$1" = "--build" ]; then
+    shift
+    BUILD="$1"
+    shift
+else
+    BUILD=$(dirname $PWD)
+fi
+
 if [ "$1" = "--tests" ]; then
     shift
     TESTS="$1"
@@ -27,5 +35,5 @@ fi
 export ROOT
 
 LD_LIBRARY_PATH="$PWD/src:$LD_LIBRARY_PATH" \
-PATH="$PWD/src:$PATH" \
-  "$PYTHON" "$ROOT/tests/cram.py" "$@" "$TESTS"
+PATH="$BUILD:$PATH" \
+  "$PYTHON" "$ROOT/../../tools/cram/cram.py" "$@" "$TESTS"


### PR DESCRIPTION
`bf-uniq` is a command that uses a bloomfilter to emulate `uniq`
behaviour without requiring the input to be sorted. It only supports
reading from stdin.

User can tune the `--probability` and `--count` parameter that maps to
the `p` and `n` in the original paper.