### PR TITLE
Aging Bloom Filter with Two Active Buffers for Dynamic Sets

### DIFF
--- a/include/twiddle/bloomfilter/bloomfilter_a2.h
+++ b/include/twiddle/bloomfilter/bloomfilter_a2.h
@@ -1,0 +1,87 @@
+#ifndef TWIDDLE_BLOOMFILTER_A2_H
+#define TWIDDLE_BLOOMFILTER_A2_H
+
+#include <twiddle/bloomfilter/bloomfilter.h>
+
+struct tw_bloomfilter_a2 {
+  float density;
+
+  struct tw_bloomfilter *active;
+  struct tw_bloomfilter *passive;
+};
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_new(uint64_t size, uint16_t k, float dentisy);
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_copy(const struct tw_bloomfilter_a2 *src,
+                       struct tw_bloomfilter_a2 *dst);
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_clone(const struct tw_bloomfilter_a2 *bf);
+
+
+void
+tw_bloomfilter_a2_free(struct tw_bloomfilter_a2 *bf);
+
+
+void
+tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf,
+                      size_t size, const char* buf);
+
+
+bool
+tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf,
+                       size_t size, const char* buf);
+
+
+bool
+tw_bloomfilter_a2_empty(const struct tw_bloomfilter_a2 *bf);
+
+
+bool
+tw_bloomfilter_a2_full(const struct tw_bloomfilter_a2 *bf);
+
+
+uint64_t
+tw_bloomfilter_a2_count(const struct tw_bloomfilter_a2 *bf);
+
+
+float
+tw_bloomfilter_a2_density(const struct tw_bloomfilter_a2 *bf);
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_zero(struct tw_bloomfilter_a2 *bf);
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_fill(struct tw_bloomfilter_a2 *bf);
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_not(struct tw_bloomfilter_a2 *bf);
+
+
+bool
+tw_bloomfilter_a2_equal(const struct tw_bloomfilter_a2 *a,
+                        const struct tw_bloomfilter_a2 *b);
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_union(const struct tw_bloomfilter_a2 *src,
+                              struct tw_bloomfilter_a2 *dst);
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_intersection(const struct tw_bloomfilter_a2 *src,
+                                     struct tw_bloomfilter_a2 *dst);
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_xor(const struct tw_bloomfilter_a2 *src,
+                            struct tw_bloomfilter_a2 *dst);
+
+#endif /* TWIDDLE_BLOOMFILTER_A2_H */

--- a/include/twiddle/bloomfilter/bloomfilter_a2.h
+++ b/include/twiddle/bloomfilter/bloomfilter_a2.h
@@ -10,78 +10,51 @@ struct tw_bloomfilter_a2 {
   struct tw_bloomfilter *passive;
 };
 
-struct tw_bloomfilter_a2 *
-tw_bloomfilter_a2_new(uint64_t size, uint16_t k, float dentisy);
-
+struct tw_bloomfilter_a2 *tw_bloomfilter_a2_new(uint64_t size, uint16_t k,
+                                                float dentisy);
 
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_copy(const struct tw_bloomfilter_a2 *src,
                        struct tw_bloomfilter_a2 *dst);
 
-
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_clone(const struct tw_bloomfilter_a2 *bf);
 
+void tw_bloomfilter_a2_free(struct tw_bloomfilter_a2 *bf);
 
-void
-tw_bloomfilter_a2_free(struct tw_bloomfilter_a2 *bf);
+void tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf, size_t size,
+                           const char *buf);
 
+bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, size_t size,
+                            const char *buf);
 
-void
-tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf,
-                      size_t size, const char* buf);
+bool tw_bloomfilter_a2_empty(const struct tw_bloomfilter_a2 *bf);
 
+bool tw_bloomfilter_a2_full(const struct tw_bloomfilter_a2 *bf);
 
-bool
-tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf,
-                       size_t size, const char* buf);
+uint64_t tw_bloomfilter_a2_count(const struct tw_bloomfilter_a2 *bf);
 
+float tw_bloomfilter_a2_density(const struct tw_bloomfilter_a2 *bf);
 
-bool
-tw_bloomfilter_a2_empty(const struct tw_bloomfilter_a2 *bf);
+struct tw_bloomfilter_a2 *tw_bloomfilter_a2_zero(struct tw_bloomfilter_a2 *bf);
 
+struct tw_bloomfilter_a2 *tw_bloomfilter_a2_fill(struct tw_bloomfilter_a2 *bf);
 
-bool
-tw_bloomfilter_a2_full(const struct tw_bloomfilter_a2 *bf);
+struct tw_bloomfilter_a2 *tw_bloomfilter_a2_not(struct tw_bloomfilter_a2 *bf);
 
-
-uint64_t
-tw_bloomfilter_a2_count(const struct tw_bloomfilter_a2 *bf);
-
-
-float
-tw_bloomfilter_a2_density(const struct tw_bloomfilter_a2 *bf);
-
-
-struct tw_bloomfilter_a2 *
-tw_bloomfilter_a2_zero(struct tw_bloomfilter_a2 *bf);
-
-
-struct tw_bloomfilter_a2 *
-tw_bloomfilter_a2_fill(struct tw_bloomfilter_a2 *bf);
-
-
-struct tw_bloomfilter_a2 *
-tw_bloomfilter_a2_not(struct tw_bloomfilter_a2 *bf);
-
-
-bool
-tw_bloomfilter_a2_equal(const struct tw_bloomfilter_a2 *a,
-                        const struct tw_bloomfilter_a2 *b);
-
+bool tw_bloomfilter_a2_equal(const struct tw_bloomfilter_a2 *a,
+                             const struct tw_bloomfilter_a2 *b);
 
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_union(const struct tw_bloomfilter_a2 *src,
-                              struct tw_bloomfilter_a2 *dst);
-
+                        struct tw_bloomfilter_a2 *dst);
 
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_intersection(const struct tw_bloomfilter_a2 *src,
-                                     struct tw_bloomfilter_a2 *dst);
-
+                               struct tw_bloomfilter_a2 *dst);
 
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_xor(const struct tw_bloomfilter_a2 *src,
-                            struct tw_bloomfilter_a2 *dst);
+                      struct tw_bloomfilter_a2 *dst);
 
 #endif /* TWIDDLE_BLOOMFILTER_A2_H */

--- a/include/twiddle/bloomfilter/bloomfilter_a2.h
+++ b/include/twiddle/bloomfilter/bloomfilter_a2.h
@@ -3,6 +3,19 @@
 
 #include <twiddle/bloomfilter/bloomfilter.h>
 
+/**
+ * struct tw_bloomfilter_a2 - aging bloom filter with active buffers
+ * @density: density threshold to trigger rotation
+ * @active:  pointer to active bloomfilter
+ * @passive: pointer to passive bloomfilter
+ *
+ * The paper "Aging bloom filter with two active buffers for dynamic sets"
+ * describe a method where 2 bloom filters are used to implement a FIFO.
+ *
+ * Elements are added to `active` until `density` (on active).
+ * Once this happen, `passive` is cleared and both filters are
+ * swapped.
+ */
 struct tw_bloomfilter_a2 {
   float density;
 
@@ -10,49 +23,175 @@ struct tw_bloomfilter_a2 {
   struct tw_bloomfilter *passive;
 };
 
+/**
+ * tw_bloomfilter_a2_new() - allocates a bloomfilter
+ * @size:    number of bits the bloomfilter should hold
+ * @k:       number of hash functions used
+ * @density: threshold for rotation (between in (0, 1])
+ *
+ * Return: NULL if allocation failed, otherwise a pointer to the newly
+ *         allocated `struct tw_bloomfilter_a2`.
+ */
 struct tw_bloomfilter_a2 *tw_bloomfilter_a2_new(uint64_t size, uint16_t k,
                                                 float dentisy);
 
+/**
+ * tw_bloomfilter_a2_free() - free a bloomfilter
+ * @bf: bloomfilter to free
+ */
+void tw_bloomfilter_a2_free(struct tw_bloomfilter_a2 *bf);
+
+/**
+ * tw_bloomfilter_a2_copy() - copy src bloomfilter into dst
+ * @src: bloomfilter to copy from
+ * @dst: bloomfilter to copy to
+ *
+ * Size of bloomfilter must be equals.
+ *
+ * Return: NULL if copy failed, otherwise a pointer to dst.
+ */
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_copy(const struct tw_bloomfilter_a2 *src,
                        struct tw_bloomfilter_a2 *dst);
 
+/**
+ * tw_bloomfilter_a2_clone() - clone a bloomfilter into a newly allocated one
+ * @bf: bloomfilter to clone
+ *
+ * Return: NULL if failed, otherwise a newly allocated bloomfilter initialized
+ * from the requested bloomfilter. The caller is responsible to deallocate
+ * with tw_bloomfilter_a2_free.
+ */
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_clone(const struct tw_bloomfilter_a2 *bf);
 
-void tw_bloomfilter_a2_free(struct tw_bloomfilter_a2 *bf);
-
+/**
+ * tw_bloomfilter_a2_set() - set an element in a bloomfilter
+ * @bf:   bloomfilter affected
+ * @size: size of the key to add
+ * @buf:  buf to the key to add
+ */
 void tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf, size_t size,
                            const char *buf);
 
+/**
+ * tw_bloomfilter_a2_test() - test an element in a bloomfilter
+ * @bf:   bloomfilter affected
+ * @size: size of the key to test
+ * @buf:  buf to the key to test
+ *
+ * Return: false if the element is not in the bloomfilter, true otherwise.
+ */
 bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, size_t size,
                             const char *buf);
 
+/**
+ * tw_bloomfilter_a2_empty() - verify if bloomfilter is empty
+ * @bf: bloomfilter to verify
+ *
+ * Return: true if the bloomfilter is empty, false otherwise.
+ */
 bool tw_bloomfilter_a2_empty(const struct tw_bloomfilter_a2 *bf);
 
+/**
+ * tw_bloomfilter_a2_full() - verify if bloomfilter is full
+ * @bf: bloomfilter to verify
+ *
+ * Return: true if both bloomfilters are full, false otherwise.
+ */
 bool tw_bloomfilter_a2_full(const struct tw_bloomfilter_a2 *bf);
 
+/**
+ * tw_bloomfilter_a2_count() - count the number of active bits
+ * @bf: bloomfilter to count
+ *
+ * Return: number of active bits in both bloomfilters
+ */
 uint64_t tw_bloomfilter_a2_count(const struct tw_bloomfilter_a2 *bf);
 
+/**
+ * tw_bloomfilter_a2_density() - count the percentage of active bits
+ * @bf: bloomfilter to count the density
+ *
+ * Return: the portion of active bits (count / size)
+ */
 float tw_bloomfilter_a2_density(const struct tw_bloomfilter_a2 *bf);
 
+/**
+ * tw_bloomfilter_a2_zero() - clear all bits in a bloomfilter
+ * @bf: bloomfilter to empty
+ *
+ * Return: the bloomfilter cleared
+ */
 struct tw_bloomfilter_a2 *tw_bloomfilter_a2_zero(struct tw_bloomfilter_a2 *bf);
 
+/**
+ * tw_bloomfilter_a2_fill() - set all bits in a bloomfilter
+ * @bf: bloomfilter to fill
+ *
+ * Return: the bloomfilter filled
+ */
 struct tw_bloomfilter_a2 *tw_bloomfilter_a2_fill(struct tw_bloomfilter_a2 *bf);
 
+/**
+ * tw_bloomfilter_a2_not() - inverse all bits and zeroes in the bloomfilter
+ * @bf: bloomfilter to inverse
+ *
+ * Return: NULL if failed, otherwise the bloomfilter.
+ */
 struct tw_bloomfilter_a2 *tw_bloomfilter_a2_not(struct tw_bloomfilter_a2 *bf);
 
+/**
+ * tw_bloomfilter_a2_equal() - verify if bloomfilters are equal
+ * @a: first bloomfilter to check
+ * @b: second bloomfilter to check
+ *
+ * Return: true if equal, false otherwise
+ *
+ * In order to be comparable, bloomfilters must have the same size and the
+ * same number of hash functions (k).
+ */
 bool tw_bloomfilter_a2_equal(const struct tw_bloomfilter_a2 *a,
                              const struct tw_bloomfilter_a2 *b);
 
+/**
+ * tw_bloomfilter_a2_union() - computer the union of bloomfilters
+ * @src: source bloomfilter to union
+ * @dst: destionation bloomfilter to union
+ *
+ * Return: NULL if failed, otherwise pointer to dst.
+ *
+ * Only works on bloomfilter of the same size and same number of hash
+ * functions(k). This store the results in dst.
+ */
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_union(const struct tw_bloomfilter_a2 *src,
                         struct tw_bloomfilter_a2 *dst);
 
+/**
+ * tw_bloomfilter_a2_intersection() - compute the intersection of bloomfilters
+ * @src: source bloomfilter to intersection
+ * @dst: destionation bloomfilter to intersection
+ *
+ * Return: NULL if failed, otherwise pointer to dst.
+ *
+ * Only works on bloomfilter of the same size and same number of hash
+ * functions(k). This store the results in dst.
+ */
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_intersection(const struct tw_bloomfilter_a2 *src,
                                struct tw_bloomfilter_a2 *dst);
 
+/**
+ * tw_bloomfilter_a2_xor() - compute the symetric difference of bloomfilters
+ * @src: source bloomfilter to xor
+ * @dst: destionation bloomfilter to xor
+ *
+ * Return: NULL if failed, otherwise pointer to dst.
+ *
+ * Only works on bloomfilter of the same size and same number of hash
+ * functions(k). This store the results in dst.
+ */
 struct tw_bloomfilter_a2 *
 tw_bloomfilter_a2_xor(const struct tw_bloomfilter_a2 *src,
                       struct tw_bloomfilter_a2 *dst);

--- a/python/tests/test_bloomfilter_a2.py
+++ b/python/tests/test_bloomfilter_a2.py
@@ -1,0 +1,12 @@
+from hypothesis import given
+from test_helpers import TwiddleTest, single_set, double_set
+from twiddle import BloomFilterA2
+
+class TestBloomFilterA2(TwiddleTest):
+  @given(single_set)
+  def test_bloomfilter_a2(self, n_xs):
+    n, xs = n_xs
+    bf = BloomFilterA2.from_iterable(n, 8, 0.5, xs)
+
+    for x in xs:
+      assert(x in bf)

--- a/python/twiddle/__init__.py
+++ b/python/twiddle/__init__.py
@@ -1,6 +1,7 @@
-from bitmap      import Bitmap
-from bitmap_rle  import BitmapRLE
-from bloomfilter import BloomFilter
-from hyperloglog import HyperLogLog
+from bitmap         import Bitmap
+from bitmap_rle     import BitmapRLE
+from bloomfilter    import BloomFilter
+from bloomfilter_a2 import BloomFilterA2
+from hyperloglog    import HyperLogLog
 
-__all__ = ['Bitmap', 'BitmapRLE', 'BloomFilter', 'HyperLogLog']
+__all__ = ['Bitmap', 'BitmapRLE', 'BloomFilter', 'BloomFilterA2', 'HyperLogLog']

--- a/python/twiddle/bloomfilter_a2.py
+++ b/python/twiddle/bloomfilter_a2.py
@@ -1,0 +1,130 @@
+from c import libtwiddle
+from ctypes import c_int, c_long, pointer
+
+class BloomFilterA2(object):
+  def __init__(self, size, k, density, ptr=None):
+    self.bloomfilter = ptr if ptr else libtwiddle.tw_bloomfilter_a2_new(size, k, density)
+    self.size        = size
+    self.k           = k
+    self.density     = density
+
+
+  def __del__(self):
+    if self.bloomfilter:
+      libtwiddle.tw_bloomfilter_a2_free(self.bloomfilter)
+
+
+  @classmethod
+  def copy(cls, b):
+    return cls(b.size, b.k, ptr=libtwiddle.tw_bloomfilter_a2_clone(b.bloomfilter))
+
+
+  @classmethod
+  def from_iterable(cls, size, k, density, iterable):
+    bloomfilter = BloomFilterA2(size, k, density)
+
+    for i in iterable:
+      bloomfilter.set(i)
+
+    return bloomfilter
+
+
+  def __len__(self):
+    return self.size
+
+
+  def __getitem__(self, x):
+    h = pointer(c_long(hash(x)))
+    return libtwiddle.tw_bloomfilter_a2_test(self.bloomfilter, 8, h)
+
+
+  def set(self, x):
+    h = pointer(c_long(hash(x)))
+    libtwiddle.tw_bloomfilter_a2_set(self.bloomfilter, 8, h)
+
+
+  def test(self, x):
+    return self[x]
+
+
+  def __contains__(self, x):
+    return self[x]
+
+
+  def __eq__(self, other):
+    if not isinstance(other, BloomFilterA2):
+      return False
+
+    return libtwiddle.tw_bloomfilter_a2_equal(self.bloomfilter, other.bloomfilter)
+
+
+  def __neg__(self):
+    ret = BloomFilterA2.copy(self)
+    libtwiddle.tw_bloomfilter_a2_not(ret.bloomfilter)
+    return ret
+
+
+  def __op(self, other, func, copy=lambda x: BloomFilterA2.copy(x)):
+    if not isinstance(other, BloomFilterA2):
+      raise ValueError("Must compare BloomFilterA2 to BloomFilterA2")
+
+    if self.size != other.size:
+      raise ValueError("BloomFiltersA2 must be of equal size to be comparable")
+
+    ret = copy(self)
+
+    func(other.bloomfilter, ret.bloomfilter)
+
+    return ret
+
+
+  def __iop(self, other, func):
+    return self.__op(other, func, copy=lambda x: x)
+
+
+  def __or__(self, other):
+    return self.__op(other, libtwiddle.tw_bloomfilter_a2_union)
+
+
+  def __ior__(self, other):
+    return self.__iop(other, libtwiddle.tw_bloomfilter_a2_union)
+
+
+  def __and__(self, other):
+    return self.__op(other, libtwiddle.tw_bloomfilter_a2_intersection)
+
+
+  def __iand__(self, other):
+    return self.__iop(other, libtwiddle.tw_bloomfilter_a2_intersection)
+
+
+  def __xor__(self, other):
+    return self.__op(other, libtwiddle.tw_bloomfilter_a2_xor)
+
+
+  def __ixor__(self, other):
+    return self.__iop(other, libtwiddle.tw_bloomfilter_a2_xor)
+
+
+  def empty(self):
+    return libtwiddle.tw_bloomfilter_a2_empty(self.bloomfilter)
+
+
+  def full(self):
+    return libtwiddle.tw_bloomfilter_a2_full(self.bloomfilter)
+
+
+  def count(self):
+    return libtwiddle.tw_bloomfilter_a2_count(self.bloomfilter)
+
+
+  def density(self):
+    return libtwiddle.tw_bloomfilter_a2_density(self.bloomfilter)
+
+
+  def zero(self):
+    libtwiddle.tw_bloomfilter_a2_zero(self.bloomfilter)
+
+
+  def fill(self):
+    libtwiddle.tw_bloomfilter_a2_fill(self.bloomfilter)

--- a/python/twiddle/c.py
+++ b/python/twiddle/c.py
@@ -190,6 +190,59 @@ libtwiddle.tw_bloomfilter_intersection.restype  = c_void_p
 libtwiddle.tw_bloomfilter_xor.argtypes = [c_void_p, c_void_p]
 libtwiddle.tw_bloomfilter_xor.restype  = c_void_p
 
+# BLOOMFILTER-A2
+
+libtwiddle.tw_bloomfilter_a2_new.argtypes = [c_ulong, c_ushort, c_float]
+libtwiddle.tw_bloomfilter_a2_new.restype  = c_void_p
+
+libtwiddle.tw_bloomfilter_a2_free.argtypes = [c_void_p]
+libtwiddle.tw_bloomfilter_a2_free.restype  = None
+
+libtwiddle.tw_bloomfilter_a2_copy.argtypes = [c_void_p, c_void_p]
+libtwiddle.tw_bloomfilter_a2_copy.restype  = c_void_p
+
+libtwiddle.tw_bloomfilter_a2_clone.argtypes = [c_void_p]
+libtwiddle.tw_bloomfilter_a2_clone.restype  = c_void_p
+
+libtwiddle.tw_bloomfilter_a2_set.argtypes = [c_void_p, c_ulong, c_void_p]
+libtwiddle.tw_bloomfilter_a2_set.restype  = None
+
+libtwiddle.tw_bloomfilter_a2_test.argtypes = [c_void_p, c_ulong, c_void_p]
+libtwiddle.tw_bloomfilter_a2_test.restype  = c_bool
+
+libtwiddle.tw_bloomfilter_a2_empty.argtypes = [c_void_p]
+libtwiddle.tw_bloomfilter_a2_empty.restype  = c_bool
+
+libtwiddle.tw_bloomfilter_a2_full.argtypes = [c_void_p]
+libtwiddle.tw_bloomfilter_a2_full.restype  = c_bool
+
+libtwiddle.tw_bloomfilter_a2_count.argtypes = [c_void_p]
+libtwiddle.tw_bloomfilter_a2_count.restype  = c_ulong
+
+libtwiddle.tw_bloomfilter_a2_density.argtypes = [c_void_p]
+libtwiddle.tw_bloomfilter_a2_density.restype  = c_float
+
+libtwiddle.tw_bloomfilter_a2_zero.argtypes = [c_void_p]
+libtwiddle.tw_bloomfilter_a2_zero.restype  = c_void_p
+
+libtwiddle.tw_bloomfilter_a2_fill.argtypes = [c_void_p]
+libtwiddle.tw_bloomfilter_a2_fill.restype  = c_void_p
+
+libtwiddle.tw_bloomfilter_a2_not.argtypes = [c_void_p]
+libtwiddle.tw_bloomfilter_a2_not.restype  = c_void_p
+
+libtwiddle.tw_bloomfilter_a2_equal.argtypes = [c_void_p, c_void_p]
+libtwiddle.tw_bloomfilter_a2_equal.restype  = c_bool
+
+libtwiddle.tw_bloomfilter_a2_union.argtypes = [c_void_p, c_void_p]
+libtwiddle.tw_bloomfilter_a2_union.restype  = c_void_p
+
+libtwiddle.tw_bloomfilter_a2_intersection.argtypes = [c_void_p, c_void_p]
+libtwiddle.tw_bloomfilter_a2_intersection.restype  = c_void_p
+
+libtwiddle.tw_bloomfilter_a2_xor.argtypes = [c_void_p, c_void_p]
+libtwiddle.tw_bloomfilter_a2_xor.restype  = c_void_p
+
  # HYPERLOGLOG
 
 libtwiddle.tw_hyperloglog_new.argtypes = [c_ushort]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ add_c_library(
         twiddle/bitmap/bitmap.c
         twiddle/bitmap/bitmap_rle.c
         twiddle/bloomfilter/bloomfilter.c
+        twiddle/bloomfilter/bloomfilter_a2.c
         twiddle/hash/hash.c
         twiddle/hash/murmur3.c
         twiddle/hash/metrohash.c

--- a/src/twiddle/bloomfilter/bloomfilter_a2.c
+++ b/src/twiddle/bloomfilter/bloomfilter_a2.c
@@ -1,0 +1,228 @@
+#include <assert.h>
+
+#include <twiddle/bloomfilter/bloomfilter_a2.h>
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_new(uint64_t size, uint16_t k, float density)
+{
+  assert(size > 0 && size <= TW_BITMAP_MAX_BITS && k > 0 &&
+         0 < density && density <= 1);
+
+  struct tw_bloomfilter_a2 *bf = calloc(1, sizeof(struct tw_bloomfilter_a2));
+
+  struct tw_bloomfilter *active = tw_bloomfilter_new(size, k);
+  if (!active) {
+    free(bf);
+    return NULL;
+  }
+
+  struct tw_bloomfilter *passive = tw_bloomfilter_new(size, k);
+  if (!passive) {
+    free(bf);
+    free(active);
+    return NULL;
+  }
+
+  bf->density = density;
+  bf->active  = active;
+  bf->passive = passive;
+
+  return bf;
+}
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_copy(const struct tw_bloomfilter_a2 *src,
+                       struct tw_bloomfilter_a2 *dst)
+{
+  assert(src && dst);
+
+  if (!tw_bloomfilter_copy(src->active,  dst->active) ||
+      !tw_bloomfilter_copy(src->passive, dst->passive)) {
+    return NULL;
+  }
+
+  return dst;
+}
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_clone(const struct tw_bloomfilter_a2 *bf)
+{
+  struct tw_bloomfilter_a2 *new =
+    tw_bloomfilter_a2_new(bf->active->bitmap->info.size,
+                          bf->active->info.k,
+                          bf->density);
+  if (!new) {
+    return NULL;
+  }
+
+  return tw_bloomfilter_a2_copy(bf, new);
+}
+
+
+void
+tw_bloomfilter_a2_free(struct tw_bloomfilter_a2 *bf)
+{
+  assert(bf);
+
+  tw_bloomfilter_free(bf->active);
+  tw_bloomfilter_free(bf->passive);
+  free(bf);
+}
+
+
+void
+tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf,
+                      size_t size, const char* buf)
+{
+  assert(bf && buf && size > 0);
+
+  /**
+   * We assume rotation is a rare event, thus the tw_unlikely hint.
+   */
+  if (tw_unlikely(tw_bloomfilter_density(bf->active) >= bf->density)) {
+    struct tw_bloomfilter *tmp = bf->passive;
+    bf->passive = bf->active;
+    bf->active = tmp;
+    tw_bloomfilter_zero(tmp);
+  }
+
+  tw_bloomfilter_set(bf->active, size, buf);
+}
+
+
+bool
+tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf,
+                       size_t size, const char* buf)
+{
+  assert(bf && buf && size > 0);
+
+  return tw_bloomfilter_test(bf->active,  size, buf) ||
+         tw_bloomfilter_test(bf->passive, size, buf);
+}
+
+
+bool
+tw_bloomfilter_a2_empty(const struct tw_bloomfilter_a2 *bf)
+{
+  assert(bf);
+
+  return tw_bloomfilter_empty(bf->active) &&
+         tw_bloomfilter_empty(bf->passive);
+}
+
+
+bool
+tw_bloomfilter_a2_full(const struct tw_bloomfilter_a2 *bf)
+{
+  assert(bf);
+
+  return tw_bloomfilter_full(bf->active) &&
+         tw_bloomfilter_full(bf->passive);
+}
+
+
+uint64_t
+tw_bloomfilter_a2_count(const struct tw_bloomfilter_a2 *bf)
+{
+  assert(bf);
+
+  return tw_bloomfilter_count(bf->active) +
+         tw_bloomfilter_count(bf->passive);
+}
+
+float
+tw_bloomfilter_a2_density(const struct tw_bloomfilter_a2 *bf)
+{
+  assert(bf);
+
+  return (tw_bloomfilter_density(bf->active) +
+          tw_bloomfilter_density(bf->passive)) / 2.0;
+}
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_zero(struct tw_bloomfilter_a2 *bf)
+{
+  assert(bf);
+
+  return (tw_bloomfilter_zero(bf->active) &&
+          tw_bloomfilter_zero(bf->passive)) ? bf : NULL;
+}
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_fill(struct tw_bloomfilter_a2 *bf)
+{
+  assert(bf);
+
+  return (tw_bloomfilter_fill(bf->active) &&
+          tw_bloomfilter_fill(bf->passive)) ? bf : NULL;
+}
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_not(struct tw_bloomfilter_a2 *bf)
+{
+  assert(bf);
+
+  return (tw_bloomfilter_not(bf->active) &&
+          tw_bloomfilter_not(bf->passive)) ? bf : NULL;
+}
+
+
+bool
+tw_bloomfilter_a2_equal(const struct tw_bloomfilter_a2 *a,
+                        const struct tw_bloomfilter_a2 *b)
+{
+  assert(a && b);
+
+  return (a->density == b->density &&
+          tw_bloomfilter_equal(a->active,  b->active) &&
+          tw_bloomfilter_equal(a->passive, b->passive));
+}
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_union(const struct tw_bloomfilter_a2 *src,
+                              struct tw_bloomfilter_a2 *dst)
+{
+  assert(src && dst);
+
+  if (src->density != dst->density) {
+    return NULL;
+  }
+
+  return (tw_bloomfilter_union(src->active,  dst->active) &&
+          tw_bloomfilter_union(src->passive, dst->passive)) ? dst : NULL;
+}
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_intersection(const struct tw_bloomfilter_a2 *src,
+                                     struct tw_bloomfilter_a2 *dst)
+{
+  assert(src && dst);
+
+  if (src->density != dst->density) {
+    return NULL;
+  }
+
+  return (tw_bloomfilter_intersection(src->active,  dst->active) &&
+          tw_bloomfilter_intersection(src->passive, dst->passive)) ? dst : NULL;
+}
+
+
+struct tw_bloomfilter_a2 *
+tw_bloomfilter_a2_xor(const struct tw_bloomfilter_a2 *src,
+                            struct tw_bloomfilter_a2 *dst)
+{
+  assert(src && dst);
+
+  if (src->density != dst->density) {
+    return NULL;
+  }
+
+  return (tw_bloomfilter_xor(src->active,  dst->active) &&
+          tw_bloomfilter_xor(src->passive, dst->passive)) ? dst : NULL;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_c_test(test-bitmap)
 add_c_test(test-bitmap-rle)
 add_c_test(test-bloomfilter)
+add_c_test(test-bloomfilter-a2)
 add_c_test(test-hyperloglog)
 
 add_subdirectory(examples)

--- a/tests/examples/CMakeLists.txt
+++ b/tests/examples/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_c_test(example-bitmap)
 add_c_test(example-bitmap-rle)
 add_c_test(example-bloomfilter)
+add_c_test(example-bloomfilter-a2)
 add_c_test(example-hyperloglog)
 
 add_c_example(bf-uniq)

--- a/tests/examples/example-bloomfilter-a2.c
+++ b/tests/examples/example-bloomfilter-a2.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+#include <string.h>
+
+#include <twiddle/bloomfilter/bloomfilter_a2.h>
+
+int main(int argc, char *argv[])
+{
+  const uint64_t nbits = 1024;
+  const uint16_t k = 7;
+  const float density = 0.50;
+  struct tw_bloomfilter_a2 *bf = tw_bloomfilter_a2_new(nbits, k, density);
+  assert(bf);
+
+  /**
+   * An active-active -bloomfilter (a2-bloomfilter) is a pair of bloomfilters,
+   * one active, one passive that gets rotated when
+   * active.density >= density_thresold is reached. Before rotation the passive
+   * bloomfilter gets cleared.
+   *
+   * Since density is applied localy to the active bloom filter, the whole
+   * bloomfilter density is maximised by 2 * density.
+   *
+   * Thus an a2-bloomfilter a bloomfilter with a LRU (on write operation)
+   * eviction policy.
+   */
+
+  for (int i = 0; i < nbits * 10; ++i) {
+    tw_bloomfilter_a2_set(bf, sizeof(i), (char *)&i);
+    assert(tw_bloomfilter_a2_density(bf) < 2 * density);
+  }
+
+  return 0;
+}

--- a/tests/test-bloomfilter-a2.c
+++ b/tests/test-bloomfilter-a2.c
@@ -1,0 +1,213 @@
+#include <stdlib.h>
+
+#include <check.h>
+
+#include <twiddle/bloomfilter/bloomfilter.h>
+#include <twiddle/bloomfilter/bloomfilter_a2.h>
+
+#include "include/helpers.h"
+
+START_TEST(test_bloomfilter_a2_basic)
+{
+  DESCRIBE_TEST;
+
+  const int32_t sizes[] = {1024, 2048, 4096, 1 << 17};
+  const int32_t ks[] = {6, 7, 8, 17};
+  const int32_t offsets[] = {-1, 0, 1};
+  const char *values[] = {"herp", "derp", "ferp", "merp"};
+
+  for (size_t i = 0; i < TW_ARRAY_SIZE(sizes); ++i) {
+    for (size_t j = 0; j < TW_ARRAY_SIZE(offsets); ++j) {
+      const int32_t nbits = sizes[i] + offsets[j];
+      const int32_t k = ks[i];
+      struct tw_bloomfilter_a2 *bf = tw_bloomfilter_a2_new(nbits, k, 0.25);
+
+      for (size_t j = 0; j < TW_ARRAY_SIZE(values); ++j) {
+        const char *value = values[j];
+        tw_bloomfilter_a2_set(bf, strlen(value), value);
+        ck_assert(tw_bloomfilter_a2_test(bf, strlen(value), value));
+      }
+
+      /**
+       * This is prone to failure and may be removed if causing problem.
+       */
+      const char *not_there = "oups!";
+      ck_assert(!tw_bloomfilter_a2_test(bf, strlen(not_there), not_there));
+
+      tw_bloomfilter_a2_free(bf);
+    }
+  }
+}
+END_TEST
+
+START_TEST(test_bloomfilter_a2_copy_and_clone)
+{
+  DESCRIBE_TEST;
+
+  const int32_t sizes[] = {1024, 2048, 4096, 1 << 17};
+  const int32_t ks[] = {6, 7, 8, 17};
+  const int32_t offsets[] = {-1, 0, 1};
+
+  const char *values[] = {"herp", "derp", "ferp", "merp"};
+
+  for (size_t i = 0; i < TW_ARRAY_SIZE(sizes); ++i) {
+    for (size_t j = 0; j < TW_ARRAY_SIZE(offsets); ++j) {
+      const int32_t nbits = sizes[i] + offsets[j];
+      const int32_t k = ks[i];
+      struct tw_bloomfilter_a2 *bf = tw_bloomfilter_a2_new(nbits, k, 0.25);
+
+      for (size_t j = 0; j < TW_ARRAY_SIZE(values); ++j) {
+        const char *value = values[j];
+        tw_bloomfilter_a2_set(bf, strlen(value), value);
+      }
+
+      struct tw_bloomfilter_a2 *copy = tw_bloomfilter_a2_new(nbits, k, 0.25);
+      tw_bloomfilter_a2_copy(bf, copy);
+      struct tw_bloomfilter_a2 *clone = tw_bloomfilter_a2_clone(copy);
+
+      for (size_t j = 0; j < TW_ARRAY_SIZE(values); ++j) {
+        const char *value = values[j];
+        ck_assert(tw_bloomfilter_a2_test(bf, strlen(value), value));
+        ck_assert(tw_bloomfilter_a2_test(copy, strlen(value), value));
+        ck_assert(tw_bloomfilter_a2_test(clone, strlen(value), value));
+      }
+
+      /**
+       * This is prone to failure and may be removed if causing problem.
+       */
+      char *not_there = "oups!";
+      ck_assert(!tw_bloomfilter_a2_test(bf, strlen(not_there), not_there));
+
+      /**
+       * Quickly validate independance
+       */
+      tw_bloomfilter_a2_zero(bf);
+      ck_assert(tw_bloomfilter_a2_empty(bf));
+      ck_assert(!tw_bloomfilter_a2_empty(copy));
+      ck_assert(!tw_bloomfilter_a2_empty(clone));
+
+      tw_bloomfilter_a2_zero(copy);
+      ck_assert(tw_bloomfilter_a2_empty(copy));
+      ck_assert(!tw_bloomfilter_a2_empty(clone));
+
+      tw_bloomfilter_a2_free(bf);
+      tw_bloomfilter_a2_free(copy);
+      tw_bloomfilter_a2_free(clone);
+    }
+  }
+}
+END_TEST
+
+START_TEST(test_bloomfilter_a2_set_operations)
+{
+  DESCRIBE_TEST;
+
+  const int32_t sizes[] = {1024, 2048, 4096};
+  const int32_t ks[] = {6, 7, 8};
+  const int32_t offsets[] = {-1, 0, 1};
+  const char *values[] = {"herp", "derp", "ferp", "merp"};
+
+  for (size_t i = 0; i < TW_ARRAY_SIZE(sizes); ++i) {
+    for (size_t j = 0; j < TW_ARRAY_SIZE(offsets); ++j) {
+      const int32_t nbits = sizes[i] + offsets[j];
+      const int32_t k = ks[i];
+      struct tw_bloomfilter_a2 *src = tw_bloomfilter_a2_new(nbits, k, 0.25);
+      struct tw_bloomfilter_a2 *dst = tw_bloomfilter_a2_new(nbits, k, 0.25);
+
+      tw_bloomfilter_a2_set(src, strlen(values[0]), values[0]);
+      tw_bloomfilter_a2_set(src, strlen(values[1]), values[1]);
+      tw_bloomfilter_a2_set(src, strlen(values[2]), values[2]);
+
+      tw_bloomfilter_a2_set(dst, strlen(values[1]), values[1]);
+      tw_bloomfilter_a2_set(dst, strlen(values[2]), values[2]);
+      tw_bloomfilter_a2_set(dst, strlen(values[3]), values[3]);
+
+      ck_assert(tw_bloomfilter_a2_intersection(src, dst) != NULL);
+      ck_assert(!tw_bloomfilter_a2_test(dst, strlen(values[0]), values[0]));
+      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[1]), values[1]));
+      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[2]), values[2]));
+      ck_assert(!tw_bloomfilter_a2_test(dst, strlen(values[3]), values[3]));
+
+      ck_assert(tw_bloomfilter_a2_union(src, dst) != NULL);
+      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[0]), values[0]));
+      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[1]), values[1]));
+      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[2]), values[2]));
+      ck_assert(!tw_bloomfilter_a2_test(dst, strlen(values[3]), values[3]));
+      ck_assert(tw_bloomfilter_a2_equal(src, dst));
+
+      tw_bloomfilter_a2_free(src);
+      tw_bloomfilter_a2_free(dst);
+    }
+  }
+}
+END_TEST
+
+START_TEST(test_bloomfilter_a2_test_rotation)
+{
+  DESCRIBE_TEST;
+  const uint64_t size = 1 << 17;
+  const uint16_t k = 10;
+  const float density = 0.25;
+
+  struct tw_bloomfilter_a2 *bf = tw_bloomfilter_a2_new(size, k, density);
+  ck_assert(bf != NULL);
+  ck_assert(tw_bloomfilter_a2_empty(bf));
+
+  const size_t rotations = 10;
+  size_t i = 0;
+
+  for (size_t j = 0; j < rotations; ++j) {
+    const size_t start = i;
+    const struct tw_bloomfilter *active = bf->active;
+    const struct tw_bloomfilter *passive = bf->passive;
+
+    // add elements until density is reached
+    while (tw_bloomfilter_density(active) < density) {
+      tw_bloomfilter_a2_set(bf, sizeof(i), (char *)&i);
+      ++i;
+    }
+
+    ck_assert(bf->active == active);
+    ck_assert(bf->passive == passive);
+
+    // trigger rotation
+    tw_bloomfilter_a2_set(bf, sizeof(i), (char *)&i);
+    ++i;
+
+    ck_assert(bf->active == passive);
+    ck_assert(bf->passive == active);
+    ck_assert(tw_bloomfilter_density(active) >= density);
+    ck_assert(tw_bloomfilter_density(passive) < density);
+    ck_assert(!tw_bloomfilter_a2_empty(bf));
+
+    // last batch should still be in bf after rotation
+    for (size_t k = start; k < i; k++) {
+      ck_assert(tw_bloomfilter_a2_test(bf, sizeof(k), (char *)&k));
+    }
+  }
+}
+END_TEST
+
+int run_tests()
+{
+  int number_failed;
+
+  Suite *s = suite_create("bloomfilter_a2");
+  SRunner *runner = srunner_create(s);
+  TCase *tc = tcase_create("basic");
+  tcase_add_test(tc, test_bloomfilter_a2_basic);
+  tcase_add_test(tc, test_bloomfilter_a2_copy_and_clone);
+  tcase_add_test(tc, test_bloomfilter_a2_set_operations);
+  tcase_add_test(tc, test_bloomfilter_a2_test_rotation);
+  suite_add_tcase(s, tc);
+  srunner_run_all(runner, CK_NORMAL);
+  number_failed = srunner_ntests_failed(runner);
+  srunner_free(runner);
+
+  return number_failed;
+}
+
+int main(int argc, char *argv[])
+{
+  return (run_tests() == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/tools/cmake/FindVersion.cmake
+++ b/tools/cmake/FindVersion.cmake
@@ -9,8 +9,8 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 if(VERSION_RESULT)
-    message(FATAL_ERROR
-            "Cannot determine version number: " ${VERSION_RESULT})
+    set(VERSION "0.0.0")
+    message(STATUS "Cannot determine version number reverting to: " ${VERSION})
 endif(VERSION_RESULT)
 message(STATUS "Current version: " ${VERSION})
 


### PR DESCRIPTION
A Bloom filter is a simple but powerful data structure that can check membership to a static set. As Bloom filters become more popular for network applications, a membership query for a dynamic set is also required. Some network applications require high-speed processing of packets. For this purpose, Bloom filters should reside in a fast and small memory, SRAM. In this case, due to the limited memory size, stale data in the Bloom filter should be deleted to make space for new data. Namely the Bloom filter needs aging like LRU caching. In this paper, we propose a new aging scheme for Bloom filters. The proposed scheme utilizes the memory space more efficiently than double buffering, the current state of the art. We prove theoretically that the proposed scheme outperforms double buffering. We also perform experiments on real Internet traces to verify the effectiveness of the proposed scheme.

http://dl.acm.org/citation.cfm?id=1685986