### PR TITLE
Feature/normalize declarations

### DIFF
--- a/include/twiddle/bloomfilter/bloomfilter.h
+++ b/include/twiddle/bloomfilter/bloomfilter.h
@@ -85,23 +85,23 @@ struct tw_bloomfilter *tw_bloomfilter_clone(const struct tw_bloomfilter *bf);
 
 /**
  * tw_bloomfilter_set() - set an element in a bloomfilter
- * @bf:   bloomfilter affected
- * @size: size of the key to add
- * @buf:  buf to the key to add
+ * @bf:       bloomfilter affected
+ * @key:      buffer of the key to add
+ * @key_size: size of the buffer key to add
  */
-void tw_bloomfilter_set(struct tw_bloomfilter *bf, size_t size,
-                        const char *buf);
+void tw_bloomfilter_set(struct tw_bloomfilter *bf, const void *key,
+                        size_t key_size);
 
 /**
  * tw_bloomfilter_test() - test an element in a bloomfilter
- * @bf:   bloomfilter affected
- * @size: size of the key to test
- * @buf:  buf to the key to test
+ * @bf:       bloomfilter affected
+ * @key:      buffer of the key to test
+ * @key_size: size of the buffer of key to test
  *
  * Return: false if the element is not in the bloomfilter, true otherwise.
  */
-bool tw_bloomfilter_test(const struct tw_bloomfilter *bf, size_t size,
-                         const char *buf);
+bool tw_bloomfilter_test(const struct tw_bloomfilter *bf, const void *key,
+                         size_t key_size);
 /**
  * tw_bloomfilter_empty() - verify if bloomfilter is empty
  * @bf: bloomfilter to verify

--- a/include/twiddle/bloomfilter/bloomfilter_a2.h
+++ b/include/twiddle/bloomfilter/bloomfilter_a2.h
@@ -67,23 +67,23 @@ tw_bloomfilter_a2_clone(const struct tw_bloomfilter_a2 *bf);
 
 /**
  * tw_bloomfilter_a2_set() - set an element in a bloomfilter
- * @bf:   bloomfilter affected
- * @size: size of the key to add
- * @buf:  buf to the key to add
+ * @bf:       bloomfilter affected
+ * @key:      buffer of the key to add
+ * @key_size: size of the buffer of the key to add
  */
-void tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf, size_t size,
-                           const char *buf);
+void tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf, const void *key,
+                           size_t key_size);
 
 /**
  * tw_bloomfilter_a2_test() - test an element in a bloomfilter
  * @bf:   bloomfilter affected
- * @size: size of the key to test
- * @buf:  buf to the key to test
+ * @key:      buffer of the key to test
+ * @key_size: size of the buffer of the key to test
  *
  * Return: false if the element is not in the bloomfilter, true otherwise.
  */
-bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, size_t size,
-                            const char *buf);
+bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, const void *key,
+                            size_t key_size);
 
 /**
  * tw_bloomfilter_a2_empty() - verify if bloomfilter is empty

--- a/include/twiddle/hash/minhash.h
+++ b/include/twiddle/hash/minhash.h
@@ -74,8 +74,13 @@ struct tw_minhash *tw_minhash_copy(const struct tw_minhash *src,
  */
 struct tw_minhash *tw_minhash_clone(const struct tw_minhash *hash);
 
-void tw_minhash_add(struct tw_minhash *hash, size_t key_size,
-                    const char *key_buf);
+/**
+ * tw_minhash_add() - add an element into a minhash structure
+ * @hash:     minhash to add
+ * @key:      buffer of the key to add
+ * @key_size: size of the buffer of the key to add
+ */
+void tw_minhash_add(struct tw_minhash *hash, const void *key, size_t key_size);
 
 /**
  * tw_minhash_estimate() - estimate the jaccard index between two minhash.

--- a/include/twiddle/hyperloglog/hyperloglog.h
+++ b/include/twiddle/hyperloglog/hyperloglog.h
@@ -96,20 +96,13 @@ struct tw_hyperloglog *tw_hyperloglog_copy(const struct tw_hyperloglog *src,
 struct tw_hyperloglog *tw_hyperloglog_clone(const struct tw_hyperloglog *hll);
 
 /**
- * tw_hyperloglog_add_hashed() - add an element in a hyperloglog structure
- * @hll:  hyperloglog affected
- * @hash: hashed value to add
- */
-void tw_hyperloglog_add_hashed(struct tw_hyperloglog *hll, uint64_t hash);
-
-/**
  * tw_hyperloglog_add() - add an element in a hyperloglog structure
  * @hll:      hyperloglog affected
+ * @key:      buffer of the key to add
  * @key_size: size of the key to add
- * @key_buf:  buf to the key to add
  */
-void tw_hyperloglog_add(struct tw_hyperloglog *hll, size_t key_size,
-                        const char *key_buf);
+void tw_hyperloglog_add(struct tw_hyperloglog *hll, const void *key,
+                        size_t key_size);
 
 /**
  * tw_hyperloglog_count() - estimate the number of elements in hll

--- a/python/twiddle/bloomfilter.py
+++ b/python/twiddle/bloomfilter.py
@@ -34,12 +34,12 @@ class BloomFilter(object):
 
   def __getitem__(self, x):
     h = pointer(c_long(hash(x)))
-    return libtwiddle.tw_bloomfilter_test(self.bloomfilter, 8, h)
+    return libtwiddle.tw_bloomfilter_test(self.bloomfilter, h, 8)
 
 
   def set(self, x):
     h = pointer(c_long(hash(x)))
-    libtwiddle.tw_bloomfilter_set(self.bloomfilter, 8, h)
+    libtwiddle.tw_bloomfilter_set(self.bloomfilter, h, 8)
 
 
   def test(self, x):

--- a/python/twiddle/bloomfilter_a2.py
+++ b/python/twiddle/bloomfilter_a2.py
@@ -35,12 +35,12 @@ class BloomFilterA2(object):
 
   def __getitem__(self, x):
     h = pointer(c_long(hash(x)))
-    return libtwiddle.tw_bloomfilter_a2_test(self.bloomfilter, 8, h)
+    return libtwiddle.tw_bloomfilter_a2_test(self.bloomfilter, h, 8)
 
 
   def set(self, x):
     h = pointer(c_long(hash(x)))
-    libtwiddle.tw_bloomfilter_a2_set(self.bloomfilter, 8, h)
+    libtwiddle.tw_bloomfilter_a2_set(self.bloomfilter, h, 8)
 
 
   def test(self, x):

--- a/python/twiddle/c.py
+++ b/python/twiddle/c.py
@@ -258,10 +258,7 @@ libtwiddle.tw_hyperloglog_copy.restype  = c_void_p
 libtwiddle.tw_hyperloglog_clone.argtypes = [c_void_p]
 libtwiddle.tw_hyperloglog_clone.restype  = c_void_p
 
-libtwiddle.tw_hyperloglog_add_hashed.argtypes = [c_void_p, c_ulong]
-libtwiddle.tw_hyperloglog_add_hashed.restype  = None
-
-libtwiddle.tw_hyperloglog_add.argtypes = [c_void_p, c_uint, c_void_p]
+libtwiddle.tw_hyperloglog_add.argtypes = [c_void_p, c_void_p, c_ulong]
 libtwiddle.tw_hyperloglog_add.restype  = None
 
 libtwiddle.tw_hyperloglog_count.argtypes = [c_void_p]

--- a/python/twiddle/c.py
+++ b/python/twiddle/c.py
@@ -284,7 +284,7 @@ libtwiddle.tw_minhash_copy.restype  = c_void_p
 libtwiddle.tw_minhash_clone.argtypes = [c_void_p]
 libtwiddle.tw_minhash_clone.restype  = c_void_p
 
-libtwiddle.tw_minhash_add.argtypes = [c_void_p, c_uint, c_void_p]
+libtwiddle.tw_minhash_add.argtypes = [c_void_p, c_void_p, c_ulong]
 libtwiddle.tw_minhash_add.restype  = None
 
 libtwiddle.tw_minhash_estimate.argtypes = [c_void_p, c_void_p]

--- a/python/twiddle/c.py
+++ b/python/twiddle/c.py
@@ -152,10 +152,10 @@ libtwiddle.tw_bloomfilter_copy.restype  = c_void_p
 libtwiddle.tw_bloomfilter_clone.argtypes = [c_void_p]
 libtwiddle.tw_bloomfilter_clone.restype  = c_void_p
 
-libtwiddle.tw_bloomfilter_set.argtypes = [c_void_p, c_ulong, c_void_p]
+libtwiddle.tw_bloomfilter_set.argtypes = [c_void_p, c_void_p, c_ulong]
 libtwiddle.tw_bloomfilter_set.restype  = None
 
-libtwiddle.tw_bloomfilter_test.argtypes = [c_void_p, c_ulong, c_void_p]
+libtwiddle.tw_bloomfilter_test.argtypes = [c_void_p, c_void_p, c_ulong]
 libtwiddle.tw_bloomfilter_test.restype  = c_bool
 
 libtwiddle.tw_bloomfilter_empty.argtypes = [c_void_p]

--- a/python/twiddle/c.py
+++ b/python/twiddle/c.py
@@ -205,10 +205,10 @@ libtwiddle.tw_bloomfilter_a2_copy.restype  = c_void_p
 libtwiddle.tw_bloomfilter_a2_clone.argtypes = [c_void_p]
 libtwiddle.tw_bloomfilter_a2_clone.restype  = c_void_p
 
-libtwiddle.tw_bloomfilter_a2_set.argtypes = [c_void_p, c_ulong, c_void_p]
+libtwiddle.tw_bloomfilter_a2_set.argtypes = [c_void_p, c_void_p,  c_ulong]
 libtwiddle.tw_bloomfilter_a2_set.restype  = None
 
-libtwiddle.tw_bloomfilter_a2_test.argtypes = [c_void_p, c_ulong, c_void_p]
+libtwiddle.tw_bloomfilter_a2_test.argtypes = [c_void_p, c_void_p, c_ulong]
 libtwiddle.tw_bloomfilter_a2_test.restype  = c_bool
 
 libtwiddle.tw_bloomfilter_a2_empty.argtypes = [c_void_p]

--- a/python/twiddle/hyperloglog.py
+++ b/python/twiddle/hyperloglog.py
@@ -33,7 +33,7 @@ class HyperLogLog(object):
 
   def add(self, x):
     h = pointer(c_long(hash(x)))
-    libtwiddle.tw_hyperloglog_add(self.hyperloglog, 8, h)
+    libtwiddle.tw_hyperloglog_add(self.hyperloglog, h, 8)
 
 
   def __eq__(self, other):

--- a/python/twiddle/minhash.py
+++ b/python/twiddle/minhash.py
@@ -29,7 +29,7 @@ class MinHash(object):
 
   def add(self, x):
     h = pointer(c_long(hash(x)))
-    libtwiddle.tw_minhash_add(self.minhash, 8, h)
+    libtwiddle.tw_minhash_add(self.minhash, h, 8)
 
 
   def __eq__(self, other):

--- a/src/twiddle/bloomfilter/bloomfilter.c
+++ b/src/twiddle/bloomfilter/bloomfilter.c
@@ -60,10 +60,11 @@ struct tw_bloomfilter *tw_bloomfilter_clone(const struct tw_bloomfilter *bf)
   return tw_bloomfilter_copy(bf, new);
 }
 
-void tw_bloomfilter_set(struct tw_bloomfilter *bf, size_t size, const char *buf)
+void tw_bloomfilter_set(struct tw_bloomfilter *bf, const void *key,
+                        size_t key_size)
 {
-  assert(bf && size > 0 && buf);
-  const tw_uint128_t hash = tw_metrohash_128(bf->info.hash_seed, buf, size);
+  assert(bf && key && key_size > 0);
+  const tw_uint128_t hash = tw_metrohash_128(bf->info.hash_seed, key, key_size);
   const uint16_t k = bf->info.k;
   struct tw_bitmap *bitmap = bf->bitmap;
   const uint32_t b_size = bitmap->info.size;
@@ -73,11 +74,11 @@ void tw_bloomfilter_set(struct tw_bloomfilter *bf, size_t size, const char *buf)
   }
 }
 
-bool tw_bloomfilter_test(const struct tw_bloomfilter *bf, size_t size,
-                         const char *buf)
+bool tw_bloomfilter_test(const struct tw_bloomfilter *bf, const void *key,
+                         size_t key_size)
 {
-  assert(bf && size > 0 && buf);
-  const tw_uint128_t hash = tw_metrohash_128(bf->info.hash_seed, buf, size);
+  assert(bf && key && key_size > 0);
+  const tw_uint128_t hash = tw_metrohash_128(bf->info.hash_seed, key, key_size);
 
   const uint16_t k = bf->info.k;
   const struct tw_bitmap *bitmap = bf->bitmap;

--- a/src/twiddle/bloomfilter/bloomfilter_a2.c
+++ b/src/twiddle/bloomfilter/bloomfilter_a2.c
@@ -85,7 +85,7 @@ void tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf, size_t size,
 
   tw_bloomfilter_a2_rotate_(bf);
 
-  tw_bloomfilter_set(bf->active, size, buf);
+  tw_bloomfilter_set(bf->active, buf, size);
 }
 
 bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, size_t size,
@@ -93,8 +93,8 @@ bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, size_t size,
 {
   assert(bf && buf && size > 0);
 
-  return tw_bloomfilter_test(bf->active, size, buf) ||
-         tw_bloomfilter_test(bf->passive, size, buf);
+  return tw_bloomfilter_test(bf->active, buf, size) ||
+         tw_bloomfilter_test(bf->passive, buf, size);
 }
 
 bool tw_bloomfilter_a2_empty(const struct tw_bloomfilter_a2 *bf)

--- a/src/twiddle/bloomfilter/bloomfilter_a2.c
+++ b/src/twiddle/bloomfilter/bloomfilter_a2.c
@@ -78,23 +78,23 @@ static inline bool tw_bloomfilter_a2_rotate_(struct tw_bloomfilter_a2 *bf)
   return false;
 }
 
-void tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf, size_t size,
-                           const char *buf)
+void tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf, const void *key,
+                           size_t key_size)
 {
-  assert(bf && buf && size > 0);
+  assert(bf && key && key_size > 0);
 
   tw_bloomfilter_a2_rotate_(bf);
 
-  tw_bloomfilter_set(bf->active, buf, size);
+  tw_bloomfilter_set(bf->active, key, key_size);
 }
 
-bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, size_t size,
-                            const char *buf)
+bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, const void *key,
+                            size_t key_size)
 {
-  assert(bf && buf && size > 0);
+  assert(bf && key && key_size > 0);
 
-  return tw_bloomfilter_test(bf->active, buf, size) ||
-         tw_bloomfilter_test(bf->passive, buf, size);
+  return tw_bloomfilter_test(bf->active, key, key_size) ||
+         tw_bloomfilter_test(bf->passive, key, key_size);
 }
 
 bool tw_bloomfilter_a2_empty(const struct tw_bloomfilter_a2 *bf)

--- a/src/twiddle/hash/minhash.c
+++ b/src/twiddle/hash/minhash.c
@@ -66,13 +66,11 @@ struct tw_minhash *tw_minhash_clone(const struct tw_minhash *hash)
   return tw_minhash_copy(hash, copy);
 }
 
-void tw_minhash_add(struct tw_minhash *hash, size_t key_size,
-                    const char *key_buf)
+void tw_minhash_add(struct tw_minhash *hash, const void *key, size_t key_size)
 {
-  assert(hash && key_size > 0 && key_buf);
+  assert(hash && key && key_size > 0);
 
-  const uint64_t hashed =
-      tw_metrohash_64(hash->info.hash_seed, key_buf, key_size);
+  const uint64_t hashed = tw_metrohash_64(hash->info.hash_seed, key, key_size);
 
   const uint32_t n_registers = hash->info.n_registers;
   for (size_t i = 0; i < n_registers; ++i) {

--- a/tests/examples/bf-uniq.c
+++ b/tests/examples/bf-uniq.c
@@ -162,9 +162,9 @@ int main(int argc, char *argv[])
       }
     }
 
-    if (!tw_bloomfilter_test(bf, line_len, line)) {
+    if (!tw_bloomfilter_test(bf, line, line_len)) {
       fprintf(stdout, "%s", line);
-      tw_bloomfilter_set(bf, line_len, line);
+      tw_bloomfilter_set(bf, line, line_len);
     }
   }
 

--- a/tests/examples/example-bloomfilter-a2.c
+++ b/tests/examples/example-bloomfilter-a2.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
    */
 
   for (int i = 0; i < nbits * 10; ++i) {
-    tw_bloomfilter_a2_set(bf, sizeof(i), (char *)&i);
+    tw_bloomfilter_a2_set(bf, (void *)&i, sizeof(i));
     assert(tw_bloomfilter_a2_density(bf) < 2 * density);
   }
 

--- a/tests/examples/example-bloomfilter.c
+++ b/tests/examples/example-bloomfilter.c
@@ -13,11 +13,11 @@ int main(int argc, char *argv[])
   char *values[] = {"herp", "derp", "ferp", "merp"};
 
   for (int i = 0; i < ((sizeof(values) / sizeof(values[0]))); ++i) {
-    tw_bloomfilter_set(bf, strlen(values[i]), values[i]);
-    assert(tw_bloomfilter_test(bf, strlen(values[i]), values[i]));
+    tw_bloomfilter_set(bf, values[i], strlen(values[i]));
+    assert(tw_bloomfilter_test(bf, values[i], strlen(values[i])));
   }
 
-  assert(!tw_bloomfilter_test(bf, sizeof("nope"), "nope"));
+  assert(!tw_bloomfilter_test(bf, "nope", sizeof("nope")));
 
   return 0;
 }

--- a/tests/examples/example-hyperloglog.c
+++ b/tests/examples/example-hyperloglog.c
@@ -11,7 +11,7 @@ int main(int argc, char *argv[])
 
   const uint32_t n_elems = 10 * (1 << precision);
   for (int i = 0; i < n_elems; ++i) {
-    tw_hyperloglog_add(hll, sizeof(i), (char *)&i);
+    tw_hyperloglog_add(hll, (void *)&i, sizeof(i));
   }
 
   printf("estimated count: %f, real count: %d\n", tw_hyperloglog_count(hll),

--- a/tests/examples/example-minhash.c
+++ b/tests/examples/example-minhash.c
@@ -13,12 +13,14 @@ int main(int argc, char *argv[])
 
   const uint32_t n_elems = 10 * n_registers;
   for (int i = 0; i < n_elems; ++i) {
+    const size_t key_size = sizeof(i);
+    const void *key = (void *)&i;
     if (i % 3 == 0) {
-      tw_minhash_add(a, sizeof(i), (char *)&i);
+      tw_minhash_add(a, key, key_size);
     }
 
     if (i % 5 == 0) {
-      tw_minhash_add(b, sizeof(i), (char *)&i);
+      tw_minhash_add(b, key, key_size);
     }
   }
 

--- a/tests/examples/hll-wc.c
+++ b/tests/examples/hll-wc.c
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
   ssize_t line_len = 0;
 
   while ((line_len = getline(&line, &buf_len, stdin)) != -1) {
-    tw_hyperloglog_add(hll, line_len, line);
+    tw_hyperloglog_add(hll, line, line_len);
     if (stream) {
       fprintf(stdout, "%" PRIu64 "\n", (uint64_t)tw_hyperloglog_count(hll));
     }

--- a/tests/test-bloomfilter-a2.c
+++ b/tests/test-bloomfilter-a2.c
@@ -24,15 +24,15 @@ START_TEST(test_bloomfilter_a2_basic)
 
       for (size_t j = 0; j < TW_ARRAY_SIZE(values); ++j) {
         const char *value = values[j];
-        tw_bloomfilter_a2_set(bf, strlen(value), value);
-        ck_assert(tw_bloomfilter_a2_test(bf, strlen(value), value));
+        tw_bloomfilter_a2_set(bf, value, strlen(value));
+        ck_assert(tw_bloomfilter_a2_test(bf, value, strlen(value)));
       }
 
       /**
        * This is prone to failure and may be removed if causing problem.
        */
       const char *not_there = "oups!";
-      ck_assert(!tw_bloomfilter_a2_test(bf, strlen(not_there), not_there));
+      ck_assert(!tw_bloomfilter_a2_test(bf, not_there, strlen(not_there)));
 
       tw_bloomfilter_a2_free(bf);
     }
@@ -58,7 +58,7 @@ START_TEST(test_bloomfilter_a2_copy_and_clone)
 
       for (size_t j = 0; j < TW_ARRAY_SIZE(values); ++j) {
         const char *value = values[j];
-        tw_bloomfilter_a2_set(bf, strlen(value), value);
+        tw_bloomfilter_a2_set(bf, value, strlen(value));
       }
 
       struct tw_bloomfilter_a2 *copy = tw_bloomfilter_a2_new(nbits, k, 0.25);
@@ -67,16 +67,16 @@ START_TEST(test_bloomfilter_a2_copy_and_clone)
 
       for (size_t j = 0; j < TW_ARRAY_SIZE(values); ++j) {
         const char *value = values[j];
-        ck_assert(tw_bloomfilter_a2_test(bf, strlen(value), value));
-        ck_assert(tw_bloomfilter_a2_test(copy, strlen(value), value));
-        ck_assert(tw_bloomfilter_a2_test(clone, strlen(value), value));
+        ck_assert(tw_bloomfilter_a2_test(bf, value, strlen(value)));
+        ck_assert(tw_bloomfilter_a2_test(copy, value, strlen(value)));
+        ck_assert(tw_bloomfilter_a2_test(clone, value, strlen(value)));
       }
 
       /**
        * This is prone to failure and may be removed if causing problem.
        */
       char *not_there = "oups!";
-      ck_assert(!tw_bloomfilter_a2_test(bf, strlen(not_there), not_there));
+      ck_assert(!tw_bloomfilter_a2_test(bf, not_there, strlen(not_there)));
 
       /**
        * Quickly validate independance
@@ -114,25 +114,25 @@ START_TEST(test_bloomfilter_a2_set_operations)
       struct tw_bloomfilter_a2 *src = tw_bloomfilter_a2_new(nbits, k, 0.25);
       struct tw_bloomfilter_a2 *dst = tw_bloomfilter_a2_new(nbits, k, 0.25);
 
-      tw_bloomfilter_a2_set(src, strlen(values[0]), values[0]);
-      tw_bloomfilter_a2_set(src, strlen(values[1]), values[1]);
-      tw_bloomfilter_a2_set(src, strlen(values[2]), values[2]);
+      tw_bloomfilter_a2_set(src, values[0], strlen(values[0]));
+      tw_bloomfilter_a2_set(src, values[1], strlen(values[1]));
+      tw_bloomfilter_a2_set(src, values[2], strlen(values[2]));
 
-      tw_bloomfilter_a2_set(dst, strlen(values[1]), values[1]);
-      tw_bloomfilter_a2_set(dst, strlen(values[2]), values[2]);
-      tw_bloomfilter_a2_set(dst, strlen(values[3]), values[3]);
+      tw_bloomfilter_a2_set(dst, values[1], strlen(values[1]));
+      tw_bloomfilter_a2_set(dst, values[2], strlen(values[2]));
+      tw_bloomfilter_a2_set(dst, values[3], strlen(values[3]));
 
       ck_assert(tw_bloomfilter_a2_intersection(src, dst) != NULL);
-      ck_assert(!tw_bloomfilter_a2_test(dst, strlen(values[0]), values[0]));
-      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[1]), values[1]));
-      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[2]), values[2]));
-      ck_assert(!tw_bloomfilter_a2_test(dst, strlen(values[3]), values[3]));
+      ck_assert(!tw_bloomfilter_a2_test(dst, values[0], strlen(values[0])));
+      ck_assert(tw_bloomfilter_a2_test(dst, values[1], strlen(values[1])));
+      ck_assert(tw_bloomfilter_a2_test(dst, values[2], strlen(values[2])));
+      ck_assert(!tw_bloomfilter_a2_test(dst, values[3], strlen(values[3])));
 
       ck_assert(tw_bloomfilter_a2_union(src, dst) != NULL);
-      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[0]), values[0]));
-      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[1]), values[1]));
-      ck_assert(tw_bloomfilter_a2_test(dst, strlen(values[2]), values[2]));
-      ck_assert(!tw_bloomfilter_a2_test(dst, strlen(values[3]), values[3]));
+      ck_assert(tw_bloomfilter_a2_test(dst, values[0], strlen(values[0])));
+      ck_assert(tw_bloomfilter_a2_test(dst, values[1], strlen(values[1])));
+      ck_assert(tw_bloomfilter_a2_test(dst, values[2], strlen(values[2])));
+      ck_assert(!tw_bloomfilter_a2_test(dst, values[3], strlen(values[3])));
       ck_assert(tw_bloomfilter_a2_equal(src, dst));
 
       tw_bloomfilter_a2_free(src);
@@ -163,7 +163,7 @@ START_TEST(test_bloomfilter_a2_test_rotation)
 
     // add elements until density is reached
     while (tw_bloomfilter_density(active) < density) {
-      tw_bloomfilter_a2_set(bf, sizeof(i), (char *)&i);
+      tw_bloomfilter_a2_set(bf, (void *)&i, sizeof(i));
       ++i;
     }
 
@@ -171,7 +171,7 @@ START_TEST(test_bloomfilter_a2_test_rotation)
     ck_assert(bf->passive == passive);
 
     // trigger rotation
-    tw_bloomfilter_a2_set(bf, sizeof(i), (char *)&i);
+    tw_bloomfilter_a2_set(bf, (void *)&i, sizeof(i));
     ++i;
 
     ck_assert(bf->active == passive);
@@ -182,7 +182,7 @@ START_TEST(test_bloomfilter_a2_test_rotation)
 
     // last batch should still be in bf after rotation
     for (size_t k = start; k < i; k++) {
-      ck_assert(tw_bloomfilter_a2_test(bf, sizeof(k), (char *)&k));
+      ck_assert(tw_bloomfilter_a2_test(bf, (void *)&k, sizeof(k)));
     }
   }
 }

--- a/tests/test-bloomfilter.c
+++ b/tests/test-bloomfilter.c
@@ -23,15 +23,15 @@ START_TEST(test_bloomfilter_basic)
 
       for (size_t j = 0; j < TW_ARRAY_SIZE(values); ++j) {
         const char *value = values[j];
-        tw_bloomfilter_set(bf, strlen(value), value);
-        ck_assert(tw_bloomfilter_test(bf, strlen(value), value));
+        tw_bloomfilter_set(bf, value, strlen(value));
+        ck_assert(tw_bloomfilter_test(bf, value, strlen(value)));
       }
 
       /**
        * This is prone to failure and may be removed if causing problem.
        */
       const char *not_there = "oups!";
-      ck_assert(!tw_bloomfilter_test(bf, strlen(not_there), not_there));
+      ck_assert(!tw_bloomfilter_test(bf, not_there, strlen(not_there)));
 
       tw_bloomfilter_free(bf);
     }
@@ -57,7 +57,7 @@ START_TEST(test_bloomfilter_copy_and_clone)
 
       for (size_t j = 0; j < TW_ARRAY_SIZE(values); ++j) {
         const char *value = values[j];
-        tw_bloomfilter_set(bf, strlen(value), value);
+        tw_bloomfilter_set(bf, value, strlen(value));
       }
 
       struct tw_bloomfilter *copy = tw_bloomfilter_new(nbits, k);
@@ -66,16 +66,16 @@ START_TEST(test_bloomfilter_copy_and_clone)
 
       for (size_t j = 0; j < TW_ARRAY_SIZE(values); ++j) {
         const char *value = values[j];
-        ck_assert(tw_bloomfilter_test(bf, strlen(value), value));
-        ck_assert(tw_bloomfilter_test(copy, strlen(value), value));
-        ck_assert(tw_bloomfilter_test(clone, strlen(value), value));
+        ck_assert(tw_bloomfilter_test(bf, value, strlen(value)));
+        ck_assert(tw_bloomfilter_test(copy, value, strlen(value)));
+        ck_assert(tw_bloomfilter_test(clone, value, strlen(value)));
       }
 
       /**
        * This is prone to failure and may be removed if causing problem.
        */
       char *not_there = "oups!";
-      ck_assert(!tw_bloomfilter_test(bf, strlen(not_there), not_there));
+      ck_assert(!tw_bloomfilter_test(bf, not_there, strlen(not_there)));
 
       /**
        * Quickly validate independance
@@ -113,25 +113,25 @@ START_TEST(test_bloomfilter_set_operations)
       struct tw_bloomfilter *src = tw_bloomfilter_new(nbits, k);
       struct tw_bloomfilter *dst = tw_bloomfilter_new(nbits, k);
 
-      tw_bloomfilter_set(src, strlen(values[0]), values[0]);
-      tw_bloomfilter_set(src, strlen(values[1]), values[1]);
-      tw_bloomfilter_set(src, strlen(values[2]), values[2]);
+      tw_bloomfilter_set(src, values[0], strlen(values[0]));
+      tw_bloomfilter_set(src, values[1], strlen(values[1]));
+      tw_bloomfilter_set(src, values[2], strlen(values[2]));
 
-      tw_bloomfilter_set(dst, strlen(values[1]), values[1]);
-      tw_bloomfilter_set(dst, strlen(values[2]), values[2]);
-      tw_bloomfilter_set(dst, strlen(values[3]), values[3]);
+      tw_bloomfilter_set(dst, values[1], strlen(values[1]));
+      tw_bloomfilter_set(dst, values[2], strlen(values[2]));
+      tw_bloomfilter_set(dst, values[3], strlen(values[3]));
 
       ck_assert(tw_bloomfilter_intersection(src, dst) != NULL);
-      ck_assert(!tw_bloomfilter_test(dst, strlen(values[0]), values[0]));
-      ck_assert(tw_bloomfilter_test(dst, strlen(values[1]), values[1]));
-      ck_assert(tw_bloomfilter_test(dst, strlen(values[2]), values[2]));
-      ck_assert(!tw_bloomfilter_test(dst, strlen(values[3]), values[3]));
+      ck_assert(!tw_bloomfilter_test(dst, values[0], strlen(values[0])));
+      ck_assert(tw_bloomfilter_test(dst, values[1], strlen(values[1])));
+      ck_assert(tw_bloomfilter_test(dst, values[2], strlen(values[2])));
+      ck_assert(!tw_bloomfilter_test(dst, values[3], strlen(values[3])));
 
       ck_assert(tw_bloomfilter_union(src, dst) != NULL);
-      ck_assert(tw_bloomfilter_test(dst, strlen(values[0]), values[0]));
-      ck_assert(tw_bloomfilter_test(dst, strlen(values[1]), values[1]));
-      ck_assert(tw_bloomfilter_test(dst, strlen(values[2]), values[2]));
-      ck_assert(!tw_bloomfilter_test(dst, strlen(values[3]), values[3]));
+      ck_assert(tw_bloomfilter_test(dst, values[0], strlen(values[0])));
+      ck_assert(tw_bloomfilter_test(dst, values[1], strlen(values[1])));
+      ck_assert(tw_bloomfilter_test(dst, values[2], strlen(values[2])));
+      ck_assert(!tw_bloomfilter_test(dst, values[3], strlen(values[3])));
       ck_assert(tw_bloomfilter_equal(src, dst));
 
       tw_bloomfilter_free(src);

--- a/tests/test-hyperloglog.c
+++ b/tests/test-hyperloglog.c
@@ -29,7 +29,7 @@ START_TEST(test_hyperloglog_basic)
     /** test linear_count */
     for (size_t k = 0; k < n_registers; ++k) {
       if (k % 2) {
-        tw_hyperloglog_add(hll, sizeof(k), (const char *)&k);
+        tw_hyperloglog_add(hll, (void *)&k, sizeof(k));
         n_elems += 1.0;
       }
     }
@@ -41,7 +41,7 @@ START_TEST(test_hyperloglog_basic)
     n_elems = 0;
     for (size_t k = 0; k < 10 * n_registers; ++k) {
       if (k % 2) {
-        tw_hyperloglog_add(hll, sizeof(k), (const char *)&k);
+        tw_hyperloglog_add(hll, (void *)&k, sizeof(k));
         n_elems += 1.0;
       }
     }
@@ -65,7 +65,7 @@ START_TEST(test_hyperloglog_copy_and_clone)
     /** test linear_count */
     for (size_t k = 0; k < n_registers; ++k) {
       if (k % 2) {
-        tw_hyperloglog_add(hll, sizeof(k), (const char *)&k);
+        tw_hyperloglog_add(hll, (void *)&k, sizeof(k));
       }
     }
 
@@ -97,9 +97,9 @@ START_TEST(test_hyperloglog_merge)
     /** test linear_count */
     for (size_t k = 0; k < times * n_registers; ++k) {
       if (k % 2) {
-        tw_hyperloglog_add(src, sizeof(k), (const char *)&k);
+        tw_hyperloglog_add(src, (void *)&k, sizeof(k));
       } else {
-        tw_hyperloglog_add(dst, sizeof(k), (const char *)&k);
+        tw_hyperloglog_add(dst, (void *)&k, sizeof(k));
       }
     }
 
@@ -138,7 +138,7 @@ START_TEST(test_hyperloglog_simd)
     /** test linear_count */
     for (size_t k = 0; k < n_registers; ++k) {
       if (k % 2) {
-        tw_hyperloglog_add(hll, sizeof(k), (const char *)&k);
+        tw_hyperloglog_add(hll, (void *)&k, sizeof(k));
         n_elems += 1.0;
       }
     }
@@ -167,7 +167,7 @@ START_TEST(test_hyperloglog_simd)
     n_elems = 0;
     for (size_t k = 0; k < 10 * n_registers; ++k) {
       if (k % 2) {
-        tw_hyperloglog_add(hll, sizeof(k), (const char *)&k);
+        tw_hyperloglog_add(hll, (void *)&k, sizeof(k));
         n_elems += 1.0;
       }
     }

--- a/tests/test-minhash.c
+++ b/tests/test-minhash.c
@@ -34,11 +34,11 @@ START_TEST(test_minhash_basic)
     int32_t intersection = 0;
     for (size_t j = 0; j < n_items; ++j) {
       const size_t key_size = sizeof(j);
-      const char *key_buf = (char *)&j;
+      const void *key = (void *)&j;
 
-      tw_minhash_add(a, key_size, key_buf);
+      tw_minhash_add(a, key, key_size);
       if (j % sample == 0) {
-        tw_minhash_add(b, key_size, key_buf);
+        tw_minhash_add(b, key, key_size);
         intersection++;
       }
     }
@@ -69,16 +69,16 @@ START_TEST(test_minhash_copy_and_clone)
     const int32_t n_items = n_registers / 2;
     for (size_t j = 0; j < n_items; ++j) {
       const size_t key_size = sizeof(j);
-      const char *key_buf = (char *)&j;
-      tw_minhash_add(a, key_size, key_buf);
+      const void *key = (void *)&j;
+      tw_minhash_add(a, key, key_size);
     }
 
     ck_assert(!tw_minhash_equal(a, b));
 
     for (size_t j = 0; j < n_items; ++j) {
       const size_t key_size = sizeof(j);
-      const char *key_buf = (char *)&j;
-      tw_minhash_add(b, key_size, key_buf);
+      const void *key = (void *)&j;
+      tw_minhash_add(b, key, key_size);
     }
 
     ck_assert(tw_minhash_equal(a, b));
@@ -111,8 +111,10 @@ START_TEST(test_minhash_merge)
 
     const int32_t n_items = n_registers * 4;
     for (size_t j = 0; j < n_items; ++j) {
-      tw_minhash_add(((j % 2) ? a : b), sizeof(j), (char *)&j);
-      tw_minhash_add(f, sizeof(j), (char *)&j);
+      const size_t key_size = sizeof(j);
+      const void *key = (void *)&j;
+      tw_minhash_add(((j % 2) ? a : b), key, key_size);
+      tw_minhash_add(f, key, key_size);
     }
 
     ck_assert(estimate_in_bounds(n_registers, 0, tw_minhash_estimate(a, b)));


### PR DESCRIPTION
The normalization is both the naming exposed and the ordering. Previously multiple variations of {(key_size|len), (key_buf|buf)} were used. Everything is now normalized to (void *key, size_t key_size).