### PR TITLE
Feature/remove asserts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 
 libtwiddle.pc
+.gdb_history
 
 /libtwiddle*.tar.gz
 /libtwiddle*.tar.bz2

--- a/include/twiddle/bitmap/bitmap.h
+++ b/include/twiddle/bitmap/bitmap.h
@@ -68,7 +68,7 @@ void tw_bitmap_free(struct tw_bitmap *bitmap);
  * @src: bitmap to copy from
  * @dst: bitmap to copy to
  *
- * Size of bitmap must be equals.
+ * `src' and `dst' must be non-null and of equal size.
  *
  * Return: NULL if copy failed, otherwise a pointer to dst.
  */
@@ -79,8 +79,10 @@ struct tw_bitmap *tw_bitmap_copy(const struct tw_bitmap *src,
  * tw_bitmap_clone() - clone a bitmap into a new allocated bitmap
  * @bitmap: bitmap to clone
  *
+ * `bitmap' must be non-null.
+ *
  * Return: NULL if failed, otherwise a newly allocated bitmap initialized from
- * the requests bitmap. The caller is responsible to deallocated the bitmap
+ * the requests bitmap. The caller is responsible to deallocate the bitmap
  * with tw_bitmap_free.
  */
 struct tw_bitmap *tw_bitmap_clone(const struct tw_bitmap *bitmap);
@@ -89,6 +91,8 @@ struct tw_bitmap *tw_bitmap_clone(const struct tw_bitmap *bitmap);
  * tw_bitmap_set() - set position in bitmap
  * @bitmap: bitmap affected
  * @pos:    position of the bit to set
+ *
+ * `bitmap' must be non-null and `pos' must be smaller than `bitmap.size'.
  */
 void tw_bitmap_set(struct tw_bitmap *bitmap, uint64_t pos);
 
@@ -96,6 +100,8 @@ void tw_bitmap_set(struct tw_bitmap *bitmap, uint64_t pos);
  * tw_bitmap_clear() - clear position in bitmap
  * @bitmap: bitmap affected
  * @pos:    position of the bit to clear
+ *
+ * `bitmap' must be non-null and `pos' must be smaller than `bitmap.size'.
  */
 void tw_bitmap_clear(struct tw_bitmap *bitmap, uint64_t pos);
 
@@ -104,7 +110,10 @@ void tw_bitmap_clear(struct tw_bitmap *bitmap, uint64_t pos);
  * @bitmap: bitmap targetted
  * @pos:    position of the bit to test
  *
- * Return: value pos in the bitmap
+ * `bitmap' must be non-null and `pos' must be smaller than `bitmap.size'.
+ *
+ * Return: false if pre-conditions are not met, otherwise return the value
+ * pos in the bitmap
  */
 bool tw_bitmap_test(const struct tw_bitmap *bitmap, uint64_t pos);
 
@@ -113,7 +122,10 @@ bool tw_bitmap_test(const struct tw_bitmap *bitmap, uint64_t pos);
  * @bitmap: bitmap affected
  * @pos:    position of the bit to test and set
  *
- * Return: value of the position in the bitmap before setting it.
+ * `bitmap' must be non-null and `pos' must be smaller than `bitmap.size'.
+ *
+ * Return: false if pre-conditions are not met, otherwise return the value
+ * pos in the bitmap before setting it.
  */
 bool tw_bitmap_test_and_set(struct tw_bitmap *bitmap, uint64_t pos);
 
@@ -122,7 +134,10 @@ bool tw_bitmap_test_and_set(struct tw_bitmap *bitmap, uint64_t pos);
  * @bitmap: bitmap affected
  * @pos:    position of the bit to test and clear
  *
- * Return: value of the position in the bitmap before clearing it.
+ * `bitmap' must be non-null and `pos' must be smaller than `bitmap.size'.
+ *
+ * Return: false if pre-conditions are not met, otherwise return the value
+ * pos in the bitmap before clearing it.
  */
 bool tw_bitmap_test_and_clear(struct tw_bitmap *bitmap, uint64_t pos);
 
@@ -130,7 +145,10 @@ bool tw_bitmap_test_and_clear(struct tw_bitmap *bitmap, uint64_t pos);
  * tw_bitmap_empty() - verify if bitmap is empty
  * @bitmap: bitmap to verify
  *
- * Return: indicator if the bitmap is empty.
+ * `bitmap' must be non-null.
+ *
+ * Return: false if pre-conditions are not met, otherwise indicator if the
+ * bitmap is empty.
  */
 bool tw_bitmap_empty(const struct tw_bitmap *bitmap);
 
@@ -138,7 +156,10 @@ bool tw_bitmap_empty(const struct tw_bitmap *bitmap);
  * tw_bitmap_full() - verify if bitmap is full
  * @bitmap: bitmap to verify
  *
- * Return: indicator if the bitmap is full.
+ * `bitmap' must be non-null.
+ *
+ * Return: false if pre-conditions are not met, otherwise indicator if the
+ * bitmap is full.
  */
 bool tw_bitmap_full(const struct tw_bitmap *bitmap);
 
@@ -146,7 +167,9 @@ bool tw_bitmap_full(const struct tw_bitmap *bitmap);
  * tw_bitmap_count() - count the number of active bits
  * @bitmap: bitmap to count
  *
- * Return: number of active bits
+ * `bitmap' must be non-null.
+ *
+ * Return: 0 if pre-conditions are not met, otherwise number of active bits.
  */
 uint64_t tw_bitmap_count(const struct tw_bitmap *bitmap);
 
@@ -154,7 +177,10 @@ uint64_t tw_bitmap_count(const struct tw_bitmap *bitmap);
  * tw_bitmap_density() - count the percentage of active bits
  * @bitmap: bitmap to count the density
  *
- * Return: the portion of active bits (count / size)
+ * `bitmap' must be non-null.
+ *
+ * Return: 0.0 if pre-conditions are not met, otherwise the portion of active
+ * bits (count / size)
  */
 float tw_bitmap_density(const struct tw_bitmap *bitmap);
 
@@ -162,7 +188,10 @@ float tw_bitmap_density(const struct tw_bitmap *bitmap);
  * tw_bitmap_zero() - clear all bits in a bitmap
  * @bitmap: bitmap to empty
  *
- * Return: the bitmap
+ * `bitmap' must be non-null.
+ *
+ * Return: NULL if pre-conditions are not met, otherwise `bitmap' with zeroed
+ * bits.
  */
 struct tw_bitmap *tw_bitmap_zero(struct tw_bitmap *bitmap);
 
@@ -170,7 +199,10 @@ struct tw_bitmap *tw_bitmap_zero(struct tw_bitmap *bitmap);
  * tw_bitmap_fill() - set all bits in a bitmap
  * @bitmap: bitmap to fill
  *
- * Return: the bitmap
+ * `bitmap' must be non-null.
+ *
+ * Return: NULL if pre-conditions are not met, otherwise `bitmap' with filled
+ * bits.
  */
 struct tw_bitmap *tw_bitmap_fill(struct tw_bitmap *bitmap);
 
@@ -178,7 +210,10 @@ struct tw_bitmap *tw_bitmap_fill(struct tw_bitmap *bitmap);
  * tw_bitmap_find_first_zero() - find the first zero
  * @bitmap: bitmap to find first zero
  *
- * Return: -1 if not found, otherwise the bit position.
+ * `bitmap' must be non-null.
+ *
+ * Return: -1 if not found or pre-conditions not met, otherwise the bit
+ * position.
  */
 int64_t tw_bitmap_find_first_zero(const struct tw_bitmap *bitmap);
 
@@ -186,7 +221,10 @@ int64_t tw_bitmap_find_first_zero(const struct tw_bitmap *bitmap);
  * tw_bitmap_find_first_bit() - find the first bit
  * @bitmap: bitmap to find first bit
  *
- * Return: -1 if not found, otherwise the bit position.
+ * `bitmap' must be non-null.
+ *
+ * Return: -1 if not found or pre-conditions are not met, otherwise the bit
+ * position.
  */
 int64_t tw_bitmap_find_first_bit(const struct tw_bitmap *bitmap);
 
@@ -194,27 +232,32 @@ int64_t tw_bitmap_find_first_bit(const struct tw_bitmap *bitmap);
  * tw_bitmap_not() - inverse all bits and zeroes in the bitmap
  * @bitmap: bitmap to inverse
  *
+ * `bitmap' must be non-null.
+ *
  * Return: NULL if failed, pointer to bitmap otherwise.
  */
 struct tw_bitmap *tw_bitmap_not(struct tw_bitmap *bitmap);
 
 /**
  * tw_bitmap_equal() - verify if bitmaps are equal
- * @a: first bitmap to check
- * @b: second bitmap to check
+ * @fst: first bitmap to check
+ * @snd: second bitmap to check
  *
- * Return: true if a and b are equal, false otherwise
+ * `fst' and `snd' must be non-null and of same size.
+ *
+ * Return: false if pre-conditions are not met or bitmaps are not equal,
+ * otherwise returns true.
  */
-bool tw_bitmap_equal(const struct tw_bitmap *a, const struct tw_bitmap *b);
+bool tw_bitmap_equal(const struct tw_bitmap *fst, const struct tw_bitmap *snd);
 
 /**
  * tw_bitmap_union() - compute the union of src and dst into dst
  * @src: source bitmap to union
  * @dst: destionation bitmap to union
  *
- * Return: NULL if failed, otherwise pointer to dst.
+ * `src' and `dst' must be non-null and of same size.
  *
- * Only works on bitmap of the same size.
+ * Return: NULL if pre-conditions are not met, otherwise pointer to dst.
  */
 struct tw_bitmap *tw_bitmap_union(const struct tw_bitmap *src,
                                   struct tw_bitmap *dst);
@@ -224,9 +267,9 @@ struct tw_bitmap *tw_bitmap_union(const struct tw_bitmap *src,
  * @src: source bitmap to intersect
  * @dst: destionation bitmap to intersect
  *
- * Return: NULL if failed, otherwise pointer to dst.
+ * `src' and `dst' must be non-null and of same size.
  *
- * Only works on bitmap of the same size.
+ * Return: NULL if pre-conditions are not met, otherwise pointer to dst.
  */
 struct tw_bitmap *tw_bitmap_intersection(const struct tw_bitmap *src,
                                          struct tw_bitmap *dst);
@@ -236,9 +279,9 @@ struct tw_bitmap *tw_bitmap_intersection(const struct tw_bitmap *src,
  * @src: source bitmap to xor
  * @dst: destionation bitmap to xor
  *
- * Return: NULL if failed, otherwise pointer to dst.
+ * `src' and `dst' must be non-null and of same size.
  *
- * Only works on bitmap of the same size.
+ * Return: NULL if pre-conditions are not met, otherwise pointer to dst.
  */
 struct tw_bitmap *tw_bitmap_xor(const struct tw_bitmap *src,
                                 struct tw_bitmap *dst);

--- a/include/twiddle/bitmap/bitmap.h
+++ b/include/twiddle/bitmap/bitmap.h
@@ -3,25 +3,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
-
-#include <twiddle/internal/utils.h>
-
-/**
- * We define the bitmap to be a 64 bits block.
- */
-#define bitmap_t uint64_t
-#define TW_BYTES_PER_BITMAP sizeof(bitmap_t)
-#define TW_BITS_PER_BITMAP (TW_BYTES_PER_BITMAP * TW_BITS_IN_WORD)
-
-#define BITMAP_POS(pos) (pos / TW_BITS_PER_BITMAP)
-#define MASK(pos) (1ULL << (pos % TW_BITS_PER_BITMAP))
-
-/**
- * Computes the number of required `bitmap_t` to hold `nbits` bits.
- */
-#define TW_BITMAP_PER_BITS(nbits) TW_DIV_ROUND_UP(nbits, TW_BITS_PER_BITMAP)
-#define TW_BITMAP_POS(nbits) (nbits / TW_BITS_PER_BITMAP)
 
 #define TW_BITMAP_MAX_BITS (1UL << 48)
 #define TW_BITMAP_MAX_POS (TW_BITMAP_MAX_BITS - 1)
@@ -42,7 +23,7 @@
 struct tw_bitmap {
   uint64_t size;
   uint64_t count;
-  bitmap_t *data;
+  uint64_t *data;
 };
 
 /**

--- a/include/twiddle/bitmap/bitmap.h
+++ b/include/twiddle/bitmap/bitmap.h
@@ -193,8 +193,8 @@ struct tw_bitmap *tw_bitmap_fill(struct tw_bitmap *bitmap);
  *
  * `bitmap' must be non-null.
  *
- * Return: -1 if not found or pre-conditions not met, otherwise the bit
- * position.
+ * Return: -1 if not found or pre-conditions not met, otherwise the position
+ * of the first zero.
  */
 int64_t tw_bitmap_find_first_zero(const struct tw_bitmap *bitmap);
 
@@ -204,8 +204,8 @@ int64_t tw_bitmap_find_first_zero(const struct tw_bitmap *bitmap);
  *
  * `bitmap' must be non-null.
  *
- * Return: -1 if not found or pre-conditions are not met, otherwise the bit
- * position.
+ * Return: -1 if not found or pre-conditions are not met, otherwise position
+ * of the first bit.
  */
 int64_t tw_bitmap_find_first_bit(const struct tw_bitmap *bitmap);
 

--- a/include/twiddle/bitmap/bitmap.h
+++ b/include/twiddle/bitmap/bitmap.h
@@ -50,7 +50,7 @@ struct tw_bitmap {
  * @size: number of bits the bitmap should hold
  *
  * Bitmaps are static and do not grow in size. Bitmaps cannot contain more
- * than TW_BITMAP_MAX_POS.
+ * than TW_BITMAP_MAX_BITS.
  *
  * Return: NULL if allocation failed, otherwise a pointer to the newly
  *         allocated `struct tw_bitmap`.

--- a/include/twiddle/bloomfilter/bloomfilter.h
+++ b/include/twiddle/bloomfilter/bloomfilter.h
@@ -6,8 +6,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define TW_BF_DEFAULT_SEED 3781869495ULL
-
 #define TW_LOG_2 0.6931471805599453
 
 #define tw_bloomfilter_optimal_m(n, p) (-n * log(p) / (TW_LOG_2 * TW_LOG_2))
@@ -33,6 +31,8 @@ struct tw_bloomfilter {
  * @size: number of bits the bloomfilter should hold
  * @k:    number of hash functions used
  *
+ * `k' must be greater than 0, `size' must be within (0, TW_BITMAP_MAX_BITS].
+ *
  * Return: NULL if allocation failed, otherwise a pointer to the newly
  *         allocated `struct tw_bloomfilter`.
  */
@@ -49,7 +49,7 @@ void tw_bloomfilter_free(struct tw_bloomfilter *bf);
  * @src: bloomfilter to copy from
  * @dst: bloomfilter to copy to
  *
- * Size of bloomfilter must be equals.
+ * `src' and `dst' must be non-null, and of equal size.
  *
  * Return: NULL if copy failed, otherwise a pointer to dst.
  */
@@ -59,6 +59,8 @@ struct tw_bloomfilter *tw_bloomfilter_copy(const struct tw_bloomfilter *src,
 /**
  * tw_bloomfilter_clone() - clone a bloomfilter into a newly allocated one
  * @bf: bloomfilter to clone
+ *
+ * `bf' must be non-null.
  *
  * Return: NULL if failed, otherwise a newly allocated bloomfilter initialized
  * from the requested bloomfilter. The caller is responsible to deallocate
@@ -71,6 +73,8 @@ struct tw_bloomfilter *tw_bloomfilter_clone(const struct tw_bloomfilter *bf);
  * @bf:       bloomfilter affected
  * @key:      buffer of the key to add
  * @key_size: size of the buffer key to add
+ *
+ * `bf' and `key' must be non-null, `key_size' must be greater than 0.
  */
 void tw_bloomfilter_set(struct tw_bloomfilter *bf, const void *key,
                         size_t key_size);
@@ -81,7 +85,10 @@ void tw_bloomfilter_set(struct tw_bloomfilter *bf, const void *key,
  * @key:      buffer of the key to test
  * @key_size: size of the buffer of key to test
  *
- * Return: false if the element is not in the bloomfilter, true otherwise.
+ * `bf' and `key' must be non-null, `key_size' must be greater than 0.
+ *
+ * Return: false if preconditions are not met, otherwise indicator if the
+ * element is in the bloomfilter (with possibility of false positives).
  */
 bool tw_bloomfilter_test(const struct tw_bloomfilter *bf, const void *key,
                          size_t key_size);
@@ -89,7 +96,10 @@ bool tw_bloomfilter_test(const struct tw_bloomfilter *bf, const void *key,
  * tw_bloomfilter_empty() - verify if bloomfilter is empty
  * @bf: bloomfilter to verify
  *
- * Return: true if the bloomfilter is empty, false otherwise.
+ * `bf' must be non-null.
+ *
+ * Return: false if preconditions are not met or the bloomfilter is not empty,
+ * true if the bloomfilter is empty.
  */
 bool tw_bloomfilter_empty(const struct tw_bloomfilter *bf);
 
@@ -97,13 +107,18 @@ bool tw_bloomfilter_empty(const struct tw_bloomfilter *bf);
  * tw_bloomfilter_full() - verify if bloomfilter is full
  * @bf: bloomfilter to verify
  *
- * Return: true if the bloomfilter is full, false otherwise.
+ * `bf' must be non-null.
+ *
+ * Return: false if preconditions are not met or the bloomfilter is not full,
+ * true if the bloomfilter is full.
  */
 bool tw_bloomfilter_full(const struct tw_bloomfilter *bf);
 
 /**
  * tw_bloomfilter_count() - count the number of active bits
  * @bf: bloomfilter to count
+ *
+ * `bf' must be non-null.
  *
  * Return: number of active bits
  */
@@ -113,6 +128,8 @@ uint64_t tw_bloomfilter_count(const struct tw_bloomfilter *bf);
  * tw_bloomfilter_density() - count the percentage of active bits
  * @bf: bloomfilter to count the density
  *
+ * `bf' must be non-null.
+ *
  * Return: the portion of active bits (count / size)
  */
 float tw_bloomfilter_density(const struct tw_bloomfilter *bf);
@@ -120,6 +137,8 @@ float tw_bloomfilter_density(const struct tw_bloomfilter *bf);
 /**
  * tw_bloomfilter_zero() - clear all bits in a bloomfilter
  * @bf: bloomfilter to empty
+ *
+ * `bf' must be non-null.
  *
  * Return: the bloomfilter cleared
  */
@@ -129,6 +148,8 @@ struct tw_bloomfilter *tw_bloomfilter_zero(struct tw_bloomfilter *bf);
  * tw_bloomfilter_fill() - set all bits in a bloomfilter
  * @bf: bloomfilter to fill
  *
+ * `bf' must be non-null.
+ *
  * Return: the bloomfilter filled
  */
 struct tw_bloomfilter *tw_bloomfilter_fill(struct tw_bloomfilter *bf);
@@ -137,14 +158,18 @@ struct tw_bloomfilter *tw_bloomfilter_fill(struct tw_bloomfilter *bf);
  * tw_bloomfilter_not() - inverse all bits and zeroes in the bloomfilter
  * @bf: bloomfilter to inverse
  *
+ * `bf' must be non-null.
+ *
  * Return: NULL if failed, otherwise the bloomfilter.
  */
 struct tw_bloomfilter *tw_bloomfilter_not(struct tw_bloomfilter *bf);
 
 /**
  * tw_bloomfilter_equal() - verify if bloomfilter are equal
- * @a: first bloomfilter to check
- * @b: second bloomfilter to check
+ * @fst: first bloomfilter to check
+ * @snd: second bloomfilter to check
+ *
+ * `fst' and `snd' must be non-null.
  *
  * Return: true if equal, false otherwise
  *
@@ -159,6 +184,8 @@ bool tw_bloomfilter_equal(const struct tw_bloomfilter *a,
  * @src: source bloomfilter to union
  * @dst: destionation bloomfilter to union
  *
+ * `src' and `dst' must be non-null and compatibles.
+ *
  * Return: NULL if failed, otherwise pointer to dst.
  *
  * Only works on bloomfilter of the same size and same number of hash
@@ -171,6 +198,8 @@ struct tw_bloomfilter *tw_bloomfilter_union(const struct tw_bloomfilter *src,
  * tw_bloomfilter_intersection() - compute the intersection of bloomfilters
  * @src: source bloomfilter to intersection
  * @dst: destionation bloomfilter to intersection
+ *
+ * `src' and `dst' must be non-null and compatibles.
  *
  * Return: NULL if failed, otherwise pointer to dst.
  *
@@ -185,6 +214,8 @@ tw_bloomfilter_intersection(const struct tw_bloomfilter *src,
  * tw_bloomfilter_xor() - compute the symetric difference of bloomfilters
  * @src: source bloomfilter to xor
  * @dst: destionation bloomfilter to xor
+ *
+ * `src' and `dst' must be non-null and compatibles.
  *
  * Return: NULL if failed, otherwise pointer to dst.
  *

--- a/include/twiddle/bloomfilter/bloomfilter.h
+++ b/include/twiddle/bloomfilter/bloomfilter.h
@@ -3,9 +3,8 @@
 
 #include <math.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
-
-#include <twiddle/bitmap/bitmap.h>
 
 #define TW_BF_DEFAULT_SEED 3781869495ULL
 
@@ -13,6 +12,8 @@
 
 #define tw_bloomfilter_optimal_m(n, p) (-n * log(p) / (TW_LOG_2 * TW_LOG_2))
 #define tw_bloomfilter_optimal_k(n, m) (m / n * TW_LOG_2)
+
+struct tw_bitmap;
 
 /**
  * struct tw_bloomfilter - bloomfilter

--- a/include/twiddle/bloomfilter/bloomfilter_a2.h
+++ b/include/twiddle/bloomfilter/bloomfilter_a2.h
@@ -30,7 +30,10 @@ struct tw_bloomfilter_a2 {
  * tw_bloomfilter_a2_new() - allocates a bloomfilter
  * @size:    number of bits the bloomfilter should hold
  * @k:       number of hash functions used
- * @density: threshold for rotation (between in (0, 1])
+ * @density: threshold for rotation
+ *
+ * `size' must be within (0, TW_BITMAP_MAX_BITS], `k' must be within
+ * (0, UINT16_MAX] and `density' within (0, 1].
  *
  * Return: NULL if allocation failed, otherwise a pointer to the newly
  *         allocated `struct tw_bloomfilter_a2`.
@@ -49,6 +52,8 @@ void tw_bloomfilter_a2_free(struct tw_bloomfilter_a2 *bf);
  * @src: bloomfilter to copy from
  * @dst: bloomfilter to copy to
  *
+ * `src' and `dst' must be non-null.
+ *
  * Size of bloomfilter must be equals.
  *
  * Return: NULL if copy failed, otherwise a pointer to dst.
@@ -60,6 +65,8 @@ tw_bloomfilter_a2_copy(const struct tw_bloomfilter_a2 *src,
 /**
  * tw_bloomfilter_a2_clone() - clone a bloomfilter into a newly allocated one
  * @bf: bloomfilter to clone
+ *
+ * `bf' must be non-null.
  *
  * Return: NULL if failed, otherwise a newly allocated bloomfilter initialized
  * from the requested bloomfilter. The caller is responsible to deallocate
@@ -83,6 +90,8 @@ void tw_bloomfilter_a2_set(struct tw_bloomfilter_a2 *bf, const void *key,
  * @key:      buffer of the key to test
  * @key_size: size of the buffer of the key to test
  *
+ * `bf' and `key' must be non-null, `key_size' must be greater than 0.
+ *
  * Return: false if the element is not in the bloomfilter, true otherwise.
  */
 bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, const void *key,
@@ -92,6 +101,8 @@ bool tw_bloomfilter_a2_test(const struct tw_bloomfilter_a2 *bf, const void *key,
  * tw_bloomfilter_a2_empty() - verify if bloomfilter is empty
  * @bf: bloomfilter to verify
  *
+ * `bf' must be non-null.
+ *
  * Return: true if the bloomfilter is empty, false otherwise.
  */
 bool tw_bloomfilter_a2_empty(const struct tw_bloomfilter_a2 *bf);
@@ -99,6 +110,8 @@ bool tw_bloomfilter_a2_empty(const struct tw_bloomfilter_a2 *bf);
 /**
  * tw_bloomfilter_a2_full() - verify if bloomfilter is full
  * @bf: bloomfilter to verify
+ *
+ * `bf' must be non-null.
  *
  * Return: true if both bloomfilters are full, false otherwise.
  */
@@ -108,6 +121,8 @@ bool tw_bloomfilter_a2_full(const struct tw_bloomfilter_a2 *bf);
  * tw_bloomfilter_a2_count() - count the number of active bits
  * @bf: bloomfilter to count
  *
+ * `bf' must be non-null.
+ *
  * Return: number of active bits in both bloomfilters
  */
 uint64_t tw_bloomfilter_a2_count(const struct tw_bloomfilter_a2 *bf);
@@ -115,6 +130,8 @@ uint64_t tw_bloomfilter_a2_count(const struct tw_bloomfilter_a2 *bf);
 /**
  * tw_bloomfilter_a2_density() - count the percentage of active bits
  * @bf: bloomfilter to count the density
+ *
+ * `bf' must be non-null.
  *
  * Return: the portion of active bits (count / size)
  */
@@ -124,6 +141,8 @@ float tw_bloomfilter_a2_density(const struct tw_bloomfilter_a2 *bf);
  * tw_bloomfilter_a2_zero() - clear all bits in a bloomfilter
  * @bf: bloomfilter to empty
  *
+ * `bf' must be non-null.
+ *
  * Return: the bloomfilter cleared
  */
 struct tw_bloomfilter_a2 *tw_bloomfilter_a2_zero(struct tw_bloomfilter_a2 *bf);
@@ -131,6 +150,8 @@ struct tw_bloomfilter_a2 *tw_bloomfilter_a2_zero(struct tw_bloomfilter_a2 *bf);
 /**
  * tw_bloomfilter_a2_fill() - set all bits in a bloomfilter
  * @bf: bloomfilter to fill
+ *
+ * `bf' must be non-null.
  *
  * Return: the bloomfilter filled
  */
@@ -140,27 +161,33 @@ struct tw_bloomfilter_a2 *tw_bloomfilter_a2_fill(struct tw_bloomfilter_a2 *bf);
  * tw_bloomfilter_a2_not() - inverse all bits and zeroes in the bloomfilter
  * @bf: bloomfilter to inverse
  *
+ * `bf' must be non-null.
+ *
  * Return: NULL if failed, otherwise the bloomfilter.
  */
 struct tw_bloomfilter_a2 *tw_bloomfilter_a2_not(struct tw_bloomfilter_a2 *bf);
 
 /**
  * tw_bloomfilter_a2_equal() - verify if bloomfilters are equal
- * @a: first bloomfilter to check
- * @b: second bloomfilter to check
+ * @fst: first bloomfilter to check
+ * @snd: second bloomfilter to check
+ *
+ * `fst' and `snd' must be non-null.
  *
  * Return: true if equal, false otherwise
  *
  * In order to be comparable, bloomfilters must have the same size and the
  * same number of hash functions (k).
  */
-bool tw_bloomfilter_a2_equal(const struct tw_bloomfilter_a2 *a,
-                             const struct tw_bloomfilter_a2 *b);
+bool tw_bloomfilter_a2_equal(const struct tw_bloomfilter_a2 *fst,
+                             const struct tw_bloomfilter_a2 *snd);
 
 /**
  * tw_bloomfilter_a2_union() - computer the union of bloomfilters
  * @src: source bloomfilter to union
  * @dst: destionation bloomfilter to union
+ *
+ * `src' and `dst' must be non-null.
  *
  * Return: NULL if failed, otherwise pointer to dst.
  *
@@ -176,6 +203,8 @@ tw_bloomfilter_a2_union(const struct tw_bloomfilter_a2 *src,
  * @src: source bloomfilter to intersection
  * @dst: destionation bloomfilter to intersection
  *
+ * `src' and `dst' must be non-null.
+ *
  * Return: NULL if failed, otherwise pointer to dst.
  *
  * Only works on bloomfilter of the same size and same number of hash
@@ -189,6 +218,8 @@ tw_bloomfilter_a2_intersection(const struct tw_bloomfilter_a2 *src,
  * tw_bloomfilter_a2_xor() - compute the symetric difference of bloomfilters
  * @src: source bloomfilter to xor
  * @dst: destionation bloomfilter to xor
+ *
+ * `src' and `dst' must be non-null.
  *
  * Return: NULL if failed, otherwise pointer to dst.
  *

--- a/include/twiddle/bloomfilter/bloomfilter_a2.h
+++ b/include/twiddle/bloomfilter/bloomfilter_a2.h
@@ -1,7 +1,10 @@
 #ifndef TWIDDLE_BLOOMFILTER_A2_H
 #define TWIDDLE_BLOOMFILTER_A2_H
 
-#include <twiddle/bloomfilter/bloomfilter.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct tw_bloomfilter;
 
 /**
  * struct tw_bloomfilter_a2 - aging bloom filter with active buffers

--- a/include/twiddle/hash/minhash.h
+++ b/include/twiddle/hash/minhash.h
@@ -2,10 +2,7 @@
 #define TWIDDLE_HASH_MINHASH_H
 
 #include <stdbool.h>
-#include <stddef.h>
 #include <stdint.h>
-
-#define TW_BYTES_PER_MINHASH_REGISTER sizeof(uint32_t)
 
 /**
  * struct tw_minhash - minhash data structure
@@ -17,17 +14,17 @@ struct tw_minhash {
   uint32_t *registers;
 };
 
-#define TW_MINHASH_DEFAULT_SEED 18014475172444421775ULL
-
 /**
  * tw_minhash_new() - allocates a minhash structure
  * @n_registers: number of 64bit registers the structure holds
  *
+ * `n_registers' must be greater than 0.
+ *
  * Return: NULL if allocation failed, otherwise a pointer to the newly
- *         allocated `struct tw_minhash`.
+ * allocated `struct tw_minhash`.
  *
  * Note: The allocation will be rounded up to the closest multiple of a
- *       cacheline.
+ * cacheline.
  */
 struct tw_minhash *tw_minhash_new(uint32_t n_registers);
 
@@ -42,9 +39,10 @@ void tw_minhash_free(struct tw_minhash *hash);
  * @src: minhash to copy from
  * @dst: minhash to copy to
  *
- * Size and seed of hashes must be equals.
+ * `src' and `dst' must be non-null and must have the same register size.
  *
- * Return: NULL if copy failed, otherwise a pointer to dst.
+ * Return: NULL if pre-conditions are not met or copy failed, otherwise a
+ * pointer to dst.
  */
 struct tw_minhash *tw_minhash_copy(const struct tw_minhash *src,
                                    struct tw_minhash *dst);
@@ -52,6 +50,8 @@ struct tw_minhash *tw_minhash_copy(const struct tw_minhash *src,
 /**
  * tw_minhash_clone() - clone a minash into a new allocated minhash
  * @hash: minhash to clone
+ *
+ * `hash' must be non-null.
  *
  * Return: NULL if failed, otherwise a newly allocated minhash initialized from
  * the requests minhash. The caller is responsible to deallocated the minhash
@@ -64,40 +64,46 @@ struct tw_minhash *tw_minhash_clone(const struct tw_minhash *hash);
  * @hash:     minhash to add
  * @key:      buffer of the key to add
  * @key_size: size of the buffer of the key to add
+ *
+ * `hash' and `key' must be non-null, `key_size' must be greater than 0.
  */
 void tw_minhash_add(struct tw_minhash *hash, const void *key, size_t key_size);
 
 /**
  * tw_minhash_estimate() - estimate the jaccard index between two minhash.
- * @a: first minhash
- * @b: second minhash
+ * @fst: first minhash
+ * @snd: second minhash
  *
- * Return: estimated jaccard index of `a` and `b`.
+ * `fst' and `snd' must be non-null and of equal size.
+ *
+ * Return: 0.0 if pre-conditions are not met, otherwise the estimated jaccard
+ * index of `fst` and `snd`.
  */
-float tw_minhash_estimate(const struct tw_minhash *a,
-                          const struct tw_minhash *b);
+float tw_minhash_estimate(const struct tw_minhash *fst,
+                          const struct tw_minhash *snd);
 
 /**
  * tw_minhash_equal() - verify if hashes are equal
- * @a: first minhash
- * @b: second minhash
+ * @fst: first minhash
+ * @snd: second minhash
  *
- * Return: true if equal, false otherwise
+ * `fst' and `snd' must be non-null and of equal size.
  *
- * Note that this function will always return false if size and/or seed are
- * not equal.
+ * Return: false if pre-conditions are not met or not equal, otherwise
+ * indicator if hashes are equal.
  */
-bool tw_minhash_equal(const struct tw_minhash *a, const struct tw_minhash *b);
+bool tw_minhash_equal(const struct tw_minhash *fst,
+                      const struct tw_minhash *snd);
 
 /**
  * tw_minhash_merge() - merge src into dst
  * @src: minhash to merge from
  * @dst: minhash to merge to
  *
- * Return: pointer to merged minhash structure dst, NULL if failed.
+ * `src' and `dst' must be non-null and of equal size.
  *
- * Merged hashes must have the same size and seed. Otherwise
- * merging is refused.
+ * Return: NULL if pre-conditions are not met, otherwise pointer to dst with
+ * merged registers.
  */
 struct tw_minhash *tw_minhash_merge(const struct tw_minhash *src,
                                     struct tw_minhash *dst);

--- a/include/twiddle/hyperloglog/hyperloglog.h
+++ b/include/twiddle/hyperloglog/hyperloglog.h
@@ -1,12 +1,9 @@
 #ifndef TWIDDLE_HYPERLOGLOG_H
 #define TWIDDLE_HYPERLOGLOG_H
 
+#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
-
-#define TW_BYTES_PER_HLL_REGISTER sizeof(uint8_t)
-#define TW_BITS_PER_HLL_REGISTER (TW_BYTES_PER_HLL * TW_BITS_IN_WORD)
 
 #define TW_HLL_ERROR_FOR_REG(reg) (1.04 / sqrt((double)(reg)))
 #define TW_HLL_REG_FOR_ERROR(err) (1.0816 / ((err) * (err)))
@@ -32,11 +29,11 @@ struct tw_hyperloglog {
   uint8_t *registers;
 };
 
-#define TW_HLL_DEFAULT_SEED 646086642ULL
-
 /**
  * tw_hyperloglog_new() - allocates a hyperloglog data structure
  * @precision: precision hyperloglog should use
+ *
+ * `precision' must be within [TW_HLL_MIN_PRECISION, TW_HLL_MAX_PRECISION].
  *
  * Return: NULL if allocation failed, otherwise a pointer to the newly
  *         allocated `struct tw_hyperloglog`.
@@ -54,7 +51,7 @@ void tw_hyperloglog_free(struct tw_hyperloglog *hll);
  * @src: hyperloglog to copy from
  * @dst: hyperloglog to copy to
  *
- * Precision of hyperloglogs must be equals.
+ * `src' and `dst' must be non-null and of same precision.
  *
  * Return: NULL if copy failed, otherwise a pointer to dst.
  */
@@ -64,6 +61,8 @@ struct tw_hyperloglog *tw_hyperloglog_copy(const struct tw_hyperloglog *src,
 /**
  * tw_hyperloglog_clone() - clone a hyperloglog into a newly allocated one
  * @hll: hyperloglog to clone
+ *
+ * `hll' must be non-null.
  *
  * Return: NULL if failed, otherwise a newly allocated hyperloglog initialized
  * from the requested hyperloglog. The caller is responsible to deallocate
@@ -76,6 +75,8 @@ struct tw_hyperloglog *tw_hyperloglog_clone(const struct tw_hyperloglog *hll);
  * @hll:      hyperloglog affected
  * @key:      buffer of the key to add
  * @key_size: size of the key to add
+ *
+ * `hll' and `key' must be non-null, and key_size must be greater than 0.
  */
 void tw_hyperloglog_add(struct tw_hyperloglog *hll, const void *key,
                         size_t key_size);
@@ -84,31 +85,34 @@ void tw_hyperloglog_add(struct tw_hyperloglog *hll, const void *key,
  * tw_hyperloglog_count() - estimate the number of elements in hll
  * @hll: hyperloglog to estimate
  *
- * Return: estimated number of elements in hll
+ * `hll' must be non-null.
+ *
+ * Return: 0.0 if hll is NULL, otherwise theestimated number of elements in hll.
  */
 double tw_hyperloglog_count(const struct tw_hyperloglog *hll);
 
 /**
  * tw_hyperloglog_equal() - verify if hyperloglog are equal
- * @a: first hyperloglog to check
- * @b: second hyperloglog to check
+ * @fst: first hyperloglog to check
+ * @snd: second hyperloglog to check
  *
- * Return: true if equal, false otherwise
+ * `src' and `dst' must be non-null and of same precision.
  *
- * In order to be comparable, hyperloglogs must have the same precision.
+ * Return: false if pre-conditions are not met, otherwise an indicator if
+ * `src' and `dst' are equal.
  */
-bool tw_hyperloglog_equal(const struct tw_hyperloglog *a,
-                          const struct tw_hyperloglog *b);
+bool tw_hyperloglog_equal(const struct tw_hyperloglog *fst,
+                          const struct tw_hyperloglog *snd);
 
 /**
  * tw_hyperloglog_merge() - merge src into dst
  * @src: hyperloglog to merge from
  * @dst: hyperloglog to merge to
  *
- * Return: pointer to merged hyperloglog structure dst, NULL if failed.
+ * `src' and `dst' must be non-null and of same precision.
  *
- * Merged hll must have the same header (precision, hash_seed). Otherwise
- * merging is refused.
+ * Return: NULL if precondition are not met, otherwise a pointer to merged
+ * `dst'.
  */
 struct tw_hyperloglog *tw_hyperloglog_merge(const struct tw_hyperloglog *src,
                                             struct tw_hyperloglog *dst);

--- a/src/twiddle/bloomfilter/bloomfilter.c
+++ b/src/twiddle/bloomfilter/bloomfilter.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdlib.h>
 
 #include <twiddle/bitmap/bitmap.h>
 #include <twiddle/bloomfilter/bloomfilter.h>

--- a/src/twiddle/bloomfilter/bloomfilter.c
+++ b/src/twiddle/bloomfilter/bloomfilter.c
@@ -1,13 +1,17 @@
-#include <assert.h>
 #include <stdlib.h>
 
 #include <twiddle/bitmap/bitmap.h>
 #include <twiddle/bloomfilter/bloomfilter.h>
 #include <twiddle/hash/metrohash.h>
 
+#define TW_BF_DEFAULT_SEED 3781869495ULL
+
 struct tw_bloomfilter *tw_bloomfilter_new(uint64_t size, uint16_t k)
 {
-  assert(size > 0 && size <= TW_BITMAP_MAX_BITS && k > 0);
+  if (!size || size > TW_BITMAP_MAX_BITS || !k) {
+    return NULL;
+  }
+
   struct tw_bloomfilter *bf = calloc(1, sizeof(struct tw_bloomfilter));
   if (!bf) {
     return NULL;
@@ -26,7 +30,10 @@ struct tw_bloomfilter *tw_bloomfilter_new(uint64_t size, uint16_t k)
 
 void tw_bloomfilter_free(struct tw_bloomfilter *bf)
 {
-  assert(bf);
+  if (!bf) {
+    return;
+  }
+
   tw_bitmap_free(bf->bitmap);
   free(bf);
 }
@@ -34,9 +41,7 @@ void tw_bloomfilter_free(struct tw_bloomfilter *bf)
 struct tw_bloomfilter *tw_bloomfilter_copy(const struct tw_bloomfilter *src,
                                            struct tw_bloomfilter *dst)
 {
-  assert(src && dst);
-
-  if (dst->bitmap->size != src->bitmap->size) {
+  if (!src || !dst || dst->bitmap->size != src->bitmap->size) {
     return NULL;
   }
 
@@ -51,7 +56,9 @@ struct tw_bloomfilter *tw_bloomfilter_copy(const struct tw_bloomfilter *src,
 
 struct tw_bloomfilter *tw_bloomfilter_clone(const struct tw_bloomfilter *bf)
 {
-  assert(bf);
+  if (!bf) {
+    return NULL;
+  }
 
   struct tw_bloomfilter *new = tw_bloomfilter_new(bf->bitmap->size, bf->k);
   if (!new) {
@@ -64,7 +71,10 @@ struct tw_bloomfilter *tw_bloomfilter_clone(const struct tw_bloomfilter *bf)
 void tw_bloomfilter_set(struct tw_bloomfilter *bf, const void *key,
                         size_t key_size)
 {
-  assert(bf && key && key_size > 0);
+  if (!bf || !key || !key_size) {
+    return;
+  }
+
   const tw_uint128_t hash = tw_metrohash_128(TW_BF_DEFAULT_SEED, key, key_size);
   const uint16_t k = bf->k;
   struct tw_bitmap *bitmap = bf->bitmap;
@@ -78,7 +88,10 @@ void tw_bloomfilter_set(struct tw_bloomfilter *bf, const void *key,
 bool tw_bloomfilter_test(const struct tw_bloomfilter *bf, const void *key,
                          size_t key_size)
 {
-  assert(bf && key && key_size > 0);
+  if (!bf || !key || !key_size) {
+    return false;
+  }
+
   const tw_uint128_t hash = tw_metrohash_128(TW_BF_DEFAULT_SEED, key, key_size);
 
   const uint16_t k = bf->k;
@@ -96,60 +109,82 @@ bool tw_bloomfilter_test(const struct tw_bloomfilter *bf, const void *key,
 
 bool tw_bloomfilter_empty(const struct tw_bloomfilter *bf)
 {
-  assert(bf);
+  if (!bf) {
+    return false;
+  }
+
   return tw_bitmap_empty(bf->bitmap);
 }
 
 bool tw_bloomfilter_full(const struct tw_bloomfilter *bf)
 {
-  assert(bf);
+  if (!bf) {
+    return false;
+  }
+
   return tw_bitmap_full(bf->bitmap);
 }
 
 uint64_t tw_bloomfilter_count(const struct tw_bloomfilter *bf)
 {
-  assert(bf);
+  if (!bf) {
+    return 0;
+  }
+
   return tw_bitmap_count(bf->bitmap);
 }
 
 float tw_bloomfilter_density(const struct tw_bloomfilter *bf)
 {
-  assert(bf);
+  if (!bf) {
+    return 0.0f;
+  }
+
   return tw_bitmap_density(bf->bitmap);
 }
 
 struct tw_bloomfilter *tw_bloomfilter_zero(struct tw_bloomfilter *bf)
 {
-  assert(bf);
+  if (!bf) {
+    return NULL;
+  }
+
   return (tw_bitmap_zero(bf->bitmap)) ? bf : NULL;
 }
 
 struct tw_bloomfilter *tw_bloomfilter_fill(struct tw_bloomfilter *bf)
 {
-  assert(bf);
+  if (!bf) {
+    return NULL;
+  }
+
   return (tw_bitmap_fill(bf->bitmap)) ? bf : NULL;
 }
 
 struct tw_bloomfilter *tw_bloomfilter_not(struct tw_bloomfilter *bf)
 {
-  assert(bf);
+  if (!bf) {
+    return NULL;
+  }
+
   return (tw_bitmap_not(bf->bitmap)) ? bf : NULL;
 }
 
 bool tw_bloomfilter_equal(const struct tw_bloomfilter *a,
                           const struct tw_bloomfilter *b)
 {
-  assert(a && b);
+  if (!a || !b) {
+    return false;
+  }
+
   return (a->k == b->k) && tw_bitmap_equal(a->bitmap, b->bitmap);
 }
 
 struct tw_bloomfilter *tw_bloomfilter_union(const struct tw_bloomfilter *src,
                                             struct tw_bloomfilter *dst)
 {
-  assert(src && dst);
-
-  if (src->k != dst->k) {
-    return NULL;
+  if (!src || !dst || src->k != dst->k) {
+    return false;
   }
 
   return (tw_bitmap_union(src->bitmap, dst->bitmap)) ? dst : NULL;
@@ -159,10 +194,8 @@ struct tw_bloomfilter *
 tw_bloomfilter_intersection(const struct tw_bloomfilter *src,
                             struct tw_bloomfilter *dst)
 {
-  assert(src && dst);
-
-  if (src->k != dst->k) {
-    return NULL;
+  if (!src || !dst || src->k != dst->k) {
+    return false;
   }
 
   return (tw_bitmap_intersection(src->bitmap, dst->bitmap)) ? dst : NULL;
@@ -171,10 +204,8 @@ tw_bloomfilter_intersection(const struct tw_bloomfilter *src,
 struct tw_bloomfilter *tw_bloomfilter_xor(const struct tw_bloomfilter *src,
                                           struct tw_bloomfilter *dst)
 {
-  assert(src && dst);
-
-  if (src->k != dst->k) {
-    return NULL;
+  if (!src || !dst || src->k != dst->k) {
+    return false;
   }
 
   return (tw_bitmap_xor(src->bitmap, dst->bitmap)) ? dst : NULL;

--- a/src/twiddle/bloomfilter/bloomfilter_a2.c
+++ b/src/twiddle/bloomfilter/bloomfilter_a2.c
@@ -1,7 +1,9 @@
 #include <assert.h>
 
-#include <twiddle/internal/utils.h>
+#include <twiddle/bitmap/bitmap.h>
+#include <twiddle/bloomfilter/bloomfilter.h>
 #include <twiddle/bloomfilter/bloomfilter_a2.h>
+#include <twiddle/internal/utils.h>
 
 struct tw_bloomfilter_a2 *tw_bloomfilter_a2_new(uint64_t size, uint16_t k,
                                                 float density)

--- a/tests/benchmarks/bench-bitmap.c
+++ b/tests/benchmarks/bench-bitmap.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include <twiddle/bitmap/bitmap.h>
 
 #include "benchmark.h"

--- a/tests/benchmarks/bench-bloomfilter.c
+++ b/tests/benchmarks/bench-bloomfilter.c
@@ -1,3 +1,5 @@
+#include <stdlib.h>
+
 #include <twiddle/bloomfilter/bloomfilter.h>
 
 #include "benchmark.h"

--- a/tests/examples/bf-uniq.c
+++ b/tests/examples/bf-uniq.c
@@ -5,6 +5,7 @@
 #include <time.h>
 
 #include <twiddle/bloomfilter/bloomfilter.h>
+#include <twiddle/internal/utils.h>
 
 static struct option long_options[] = {
     {"probability", required_argument, 0, 'p'},

--- a/tests/test-bitmap-rle.c
+++ b/tests/test-bitmap-rle.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 
+#include <twiddle/bitmap/bitmap.h>
 #include <twiddle/bitmap/bitmap_rle.h>
 #include <twiddle/internal/utils.h>
 
@@ -465,6 +466,54 @@ START_TEST(test_bitmap_rle_intersection_advanced)
 }
 END_TEST
 
+START_TEST(test_bitmap_rle_errors)
+{
+  DESCRIBE_TEST;
+
+  const size_t a_size = 1 << 16, b_size = (1 << 16) + 1;
+
+  struct tw_bitmap_rle *a = tw_bitmap_rle_new(a_size);
+  struct tw_bitmap_rle *b = tw_bitmap_rle_new(b_size);
+
+  ck_assert_ptr_eq(tw_bitmap_rle_new(0), NULL);
+  ck_assert_ptr_eq(tw_bitmap_rle_new(TW_BITMAP_MAX_BITS + 1), NULL);
+
+  ck_assert_ptr_eq(tw_bitmap_rle_copy(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_rle_copy(NULL, a), NULL);
+  ck_assert_ptr_eq(tw_bitmap_rle_clone(NULL), NULL);
+
+  /* This should not raise a segfault. */
+  tw_bitmap_rle_set(NULL, a_size);
+  tw_bitmap_rle_set(a, a_size);
+  tw_bitmap_rle_set(a, a_size + 1);
+  ck_assert(!tw_bitmap_rle_test(NULL, a_size));
+  ck_assert(!tw_bitmap_rle_test(a, a_size));
+  ck_assert(!tw_bitmap_rle_test(a, a_size + 1));
+
+  ck_assert(!tw_bitmap_rle_empty(NULL));
+  ck_assert(!tw_bitmap_rle_full(NULL));
+  ck_assert_int_eq(tw_bitmap_rle_count(NULL), 0);
+  ck_assert_ptr_eq(tw_bitmap_rle_zero(NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_rle_fill(NULL), NULL);
+  ck_assert_int_eq(tw_bitmap_rle_find_first_zero(NULL), -1);
+  ck_assert_int_eq(tw_bitmap_rle_find_first_bit(NULL), -1);
+
+  ck_assert_ptr_eq(tw_bitmap_rle_not(NULL, NULL), NULL);
+  ck_assert(!tw_bitmap_rle_equal(NULL, NULL));
+  ck_assert(!tw_bitmap_rle_equal(a, NULL));
+  ck_assert(!tw_bitmap_rle_equal(NULL, a));
+  ck_assert_ptr_eq(tw_bitmap_rle_union(a, NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_rle_union(NULL, a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_rle_union(a, b, NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_rle_intersection(a, NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_rle_intersection(NULL, a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_rle_intersection(a, b, NULL), NULL);
+
+  tw_bitmap_rle_free(b);
+  tw_bitmap_rle_free(a);
+}
+END_TEST
+
 int run_tests()
 {
   int number_failed;
@@ -478,6 +527,7 @@ int run_tests()
   tcase_add_test(basic, test_bitmap_rle_copy_and_clone);
   tcase_add_test(basic, test_bitmap_rle_zero_and_fill);
   tcase_add_test(basic, test_bitmap_rle_find_first);
+  tcase_add_test(basic, test_bitmap_rle_errors);
   tcase_set_timeout(basic, 15);
   suite_add_tcase(s, basic);
 

--- a/tests/test-bitmap.c
+++ b/tests/test-bitmap.c
@@ -253,6 +253,62 @@ START_TEST(test_bitmap_set_operations)
 }
 END_TEST
 
+START_TEST(test_bitmap_errors)
+{
+  DESCRIBE_TEST;
+
+  const size_t a_size = 1 << 16, b_size = (1 << 16) + 1;
+
+  struct tw_bitmap *a = tw_bitmap_new(a_size);
+  struct tw_bitmap *b = tw_bitmap_new(b_size);
+
+  ck_assert_ptr_eq(tw_bitmap_new(0), NULL);
+  ck_assert_ptr_eq(tw_bitmap_new(TW_BITMAP_MAX_BITS), NULL);
+
+  ck_assert_ptr_eq(tw_bitmap_clone(NULL), NULL);
+
+  /* This should not raise a segfault. */
+  tw_bitmap_set(a, a_size);
+  tw_bitmap_set(a, a_size + 1);
+  tw_bitmap_clear(a, a_size);
+  tw_bitmap_clear(a, a_size + 1);
+  ck_assert(!tw_bitmap_test(a, a_size));
+  ck_assert(!tw_bitmap_test(a, a_size + 1));
+
+  ck_assert(!tw_bitmap_test_and_set(NULL, a_size));
+  ck_assert(!tw_bitmap_test_and_set(a, a_size));
+  ck_assert(!tw_bitmap_test_and_set(a, a_size + 1));
+
+  ck_assert(!tw_bitmap_test_and_clear(NULL, a_size));
+  ck_assert(!tw_bitmap_test_and_clear(a, a_size));
+  ck_assert(!tw_bitmap_test_and_clear(a, a_size + 1));
+
+  ck_assert(!tw_bitmap_empty(NULL));
+  ck_assert(!tw_bitmap_full(NULL));
+  ck_assert_int_eq(tw_bitmap_count(NULL), 0);
+  ck_assert_ptr_eq(tw_bitmap_zero(NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_fill(NULL), NULL);
+  ck_assert_int_eq(tw_bitmap_find_first_zero(NULL), -1);
+  ck_assert_int_eq(tw_bitmap_find_first_bit(NULL), -1);
+
+  ck_assert_ptr_eq(tw_bitmap_not(NULL), NULL);
+  ck_assert(!tw_bitmap_equal(a, NULL));
+  ck_assert(!tw_bitmap_equal(NULL, a));
+  ck_assert_ptr_eq(tw_bitmap_union(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_union(NULL, a), NULL);
+  ck_assert_ptr_eq(tw_bitmap_union(a, b), NULL);
+  ck_assert_ptr_eq(tw_bitmap_intersection(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_intersection(NULL, a), NULL);
+  ck_assert_ptr_eq(tw_bitmap_intersection(a, b), NULL);
+  ck_assert_ptr_eq(tw_bitmap_xor(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bitmap_xor(NULL, a), NULL);
+  ck_assert_ptr_eq(tw_bitmap_xor(a, b), NULL);
+
+  tw_bitmap_free(b);
+  tw_bitmap_free(a);
+}
+END_TEST
+
 int run_tests()
 {
   int number_failed;
@@ -267,6 +323,7 @@ int run_tests()
   tcase_add_test(tc, test_bitmap_zero_and_fill);
   tcase_add_test(tc, test_bitmap_find_first);
   tcase_add_test(tc, test_bitmap_set_operations);
+  tcase_add_test(tc, test_bitmap_errors);
   suite_add_tcase(s, tc);
 
   srunner_run_all(runner, CK_NORMAL);

--- a/tests/test-bloomfilter-a2.c
+++ b/tests/test-bloomfilter-a2.c
@@ -189,6 +189,68 @@ START_TEST(test_bloomfilter_a2_test_rotation)
 }
 END_TEST
 
+START_TEST(test_bloomfilter_a2_errors)
+{
+  DESCRIBE_TEST;
+
+  uint8_t k = 8;
+  uint64_t size = 1 << 18;
+  float density = 0.75;
+
+  struct tw_bloomfilter_a2 *a = tw_bloomfilter_a2_new(size, k, density),
+                           *b = tw_bloomfilter_a2_new(size + 1, k, density),
+                           *c = tw_bloomfilter_a2_new(size, k + 1,
+                                                      density + 0.05);
+
+  ck_assert_ptr_eq(tw_bloomfilter_a2_clone(NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_copy(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_copy(NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_copy(a, b), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_copy(a, c), c);
+
+  tw_bloomfilter_a2_set(NULL, NULL, 0);
+  tw_bloomfilter_a2_set(a, NULL, 1);
+  tw_bloomfilter_a2_set(a, &k, 0);
+
+  tw_bloomfilter_a2_fill(a);
+
+  ck_assert(!tw_bloomfilter_a2_test(NULL, NULL, 0));
+  ck_assert(!tw_bloomfilter_a2_test(a, NULL, 1));
+  ck_assert(!tw_bloomfilter_a2_test(a, &k, 0));
+
+  ck_assert(!tw_bloomfilter_a2_empty(NULL));
+  ck_assert(!tw_bloomfilter_a2_full(NULL));
+  ck_assert_int_eq(tw_bloomfilter_a2_count(NULL), 0);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_zero(NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_fill(NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_not(NULL), NULL);
+
+  ck_assert(!tw_bloomfilter_a2_equal(NULL, NULL));
+  ck_assert(!tw_bloomfilter_a2_equal(a, NULL));
+  ck_assert(!tw_bloomfilter_a2_equal(a, b));
+  ck_assert(!tw_bloomfilter_a2_equal(a, c));
+
+  ck_assert_ptr_eq(tw_bloomfilter_a2_union(NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_union(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_union(NULL, b), NULL);
+
+  ck_assert_ptr_eq(tw_bloomfilter_a2_intersection(NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_intersection(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_intersection(NULL, b), NULL);
+
+  ck_assert_ptr_eq(tw_bloomfilter_a2_xor(NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_xor(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_a2_xor(NULL, b), NULL);
+
+  tw_bloomfilter_a2_density(NULL);
+
+  tw_bloomfilter_a2_free(NULL);
+  tw_bloomfilter_a2_free(c);
+  tw_bloomfilter_a2_free(b);
+  tw_bloomfilter_a2_free(a);
+}
+END_TEST
+
 int run_tests()
 {
   int number_failed;
@@ -200,6 +262,7 @@ int run_tests()
   tcase_add_test(tc, test_bloomfilter_a2_copy_and_clone);
   tcase_add_test(tc, test_bloomfilter_a2_set_operations);
   tcase_add_test(tc, test_bloomfilter_a2_test_rotation);
+  tcase_add_test(tc, test_bloomfilter_a2_errors);
   suite_add_tcase(s, tc);
   srunner_run_all(runner, CK_NORMAL);
   number_failed = srunner_ntests_failed(runner);

--- a/tests/test-bloomfilter-a2.c
+++ b/tests/test-bloomfilter-a2.c
@@ -2,6 +2,7 @@
 
 #include <twiddle/bloomfilter/bloomfilter.h>
 #include <twiddle/bloomfilter/bloomfilter_a2.h>
+#include <twiddle/internal/utils.h>
 
 #include "test.h"
 

--- a/tests/test-bloomfilter.c
+++ b/tests/test-bloomfilter.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 
 #include <twiddle/bloomfilter/bloomfilter.h>
+#include <twiddle/internal/utils.h>
 
 #include "test.h"
 

--- a/tests/test-bloomfilter.c
+++ b/tests/test-bloomfilter.c
@@ -140,6 +140,66 @@ START_TEST(test_bloomfilter_set_operations)
 }
 END_TEST
 
+START_TEST(test_bloomfilter_errors)
+{
+  DESCRIBE_TEST;
+
+  uint8_t k = 8;
+  uint64_t size = 1 << 18;
+
+  struct tw_bloomfilter *a = tw_bloomfilter_new(size, k),
+                        *b = tw_bloomfilter_new(size + 1, k),
+                        *c = tw_bloomfilter_new(size, k + 1);
+
+  ck_assert_ptr_eq(tw_bloomfilter_clone(NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_copy(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_copy(NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_copy(a, b), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_copy(a, c), c);
+
+  tw_bloomfilter_set(NULL, NULL, 0);
+  tw_bloomfilter_set(a, NULL, 1);
+  tw_bloomfilter_set(a, &k, 0);
+
+  tw_bloomfilter_fill(a);
+
+  ck_assert(!tw_bloomfilter_test(NULL, NULL, 0));
+  ck_assert(!tw_bloomfilter_test(a, NULL, 1));
+  ck_assert(!tw_bloomfilter_test(a, &k, 0));
+
+  ck_assert(!tw_bloomfilter_empty(NULL));
+  ck_assert(!tw_bloomfilter_full(NULL));
+  ck_assert_int_eq(tw_bloomfilter_count(NULL), 0);
+  ck_assert_ptr_eq(tw_bloomfilter_zero(NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_fill(NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_not(NULL), NULL);
+
+  ck_assert(!tw_bloomfilter_equal(NULL, NULL));
+  ck_assert(!tw_bloomfilter_equal(a, NULL));
+  ck_assert(!tw_bloomfilter_equal(a, b));
+  ck_assert(!tw_bloomfilter_equal(a, c));
+
+  ck_assert_ptr_eq(tw_bloomfilter_union(NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_union(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_union(NULL, b), NULL);
+
+  ck_assert_ptr_eq(tw_bloomfilter_intersection(NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_intersection(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_intersection(NULL, b), NULL);
+
+  ck_assert_ptr_eq(tw_bloomfilter_xor(NULL, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_xor(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_bloomfilter_xor(NULL, b), NULL);
+
+  tw_bloomfilter_density(NULL);
+
+  tw_bloomfilter_free(NULL);
+  tw_bloomfilter_free(c);
+  tw_bloomfilter_free(b);
+  tw_bloomfilter_free(a);
+}
+END_TEST
+
 int run_tests()
 {
   int number_failed;
@@ -150,6 +210,7 @@ int run_tests()
   tcase_add_test(tc, test_bloomfilter_basic);
   tcase_add_test(tc, test_bloomfilter_copy_and_clone);
   tcase_add_test(tc, test_bloomfilter_set_operations);
+  tcase_add_test(tc, test_bloomfilter_errors);
   suite_add_tcase(s, tc);
   srunner_run_all(runner, CK_NORMAL);
   number_failed = srunner_ntests_failed(runner);

--- a/tests/test-hyperloglog.c
+++ b/tests/test-hyperloglog.c
@@ -195,6 +195,43 @@ START_TEST(test_hyperloglog_simd)
 }
 END_TEST
 
+START_TEST(test_hyperloglog_errors)
+{
+  DESCRIBE_TEST;
+
+  const uint8_t a_precision = TW_HLL_MIN_PRECISION,
+                b_precision = TW_HLL_MIN_PRECISION + 1;
+
+  struct tw_hyperloglog *a = tw_hyperloglog_new(a_precision);
+  struct tw_hyperloglog *b = tw_hyperloglog_new(b_precision);
+
+  ck_assert_ptr_eq(tw_hyperloglog_new(TW_HLL_MIN_PRECISION - 1), NULL);
+  ck_assert_ptr_eq(tw_hyperloglog_new(TW_HLL_MAX_PRECISION + 1), NULL);
+
+  ck_assert_ptr_eq(tw_hyperloglog_copy(a, b), NULL);
+  ck_assert_ptr_eq(tw_hyperloglog_clone(NULL), NULL);
+
+  tw_hyperloglog_add(NULL, NULL, 0);
+  tw_hyperloglog_add(a, NULL, 1);
+  tw_hyperloglog_add(a, &a_precision, 0);
+  tw_hyperloglog_add(a, &a_precision, 1);
+
+  tw_hyperloglog_count(NULL);
+
+  ck_assert(!tw_hyperloglog_equal(a, b));
+  ck_assert(!tw_hyperloglog_equal(NULL, b));
+  ck_assert(!tw_hyperloglog_equal(a, NULL));
+
+  ck_assert_ptr_eq(tw_hyperloglog_merge(a, b), NULL);
+  ck_assert_ptr_eq(tw_hyperloglog_merge(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_hyperloglog_merge(NULL, b), NULL);
+
+  tw_hyperloglog_free(NULL);
+  tw_hyperloglog_free(b);
+  tw_hyperloglog_free(a);
+}
+END_TEST
+
 int run_tests()
 {
   int number_failed;
@@ -206,6 +243,7 @@ int run_tests()
   tcase_add_test(tc, test_hyperloglog_copy_and_clone);
   tcase_add_test(tc, test_hyperloglog_merge);
   tcase_add_test(tc, test_hyperloglog_simd);
+  tcase_add_test(tc, test_hyperloglog_errors);
   tcase_set_timeout(tc, 15);
   suite_add_tcase(s, tc);
   srunner_run_all(runner, CK_NORMAL);

--- a/tests/test-minhash.c
+++ b/tests/test-minhash.c
@@ -2,8 +2,8 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#include <twiddle/internal/utils.h>
 #include <twiddle/hash/minhash.h>
+#include <twiddle/internal/utils.h>
 
 #include "test.h"
 
@@ -140,6 +140,45 @@ START_TEST(test_minhash_merge)
 }
 END_TEST
 
+START_TEST(test_minhash_errors)
+{
+  DESCRIBE_TEST;
+
+  const uint32_t a_size = 1 << 16, b_size = (1 << 16) + 1;
+
+  struct tw_minhash *a = tw_minhash_new(a_size);
+  struct tw_minhash *b = tw_minhash_new(b_size);
+
+  ck_assert_ptr_eq(tw_minhash_new(0), NULL);
+
+  ck_assert_ptr_eq(tw_minhash_copy(a, b), NULL);
+  ck_assert_ptr_eq(tw_minhash_copy(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_minhash_copy(NULL, a), NULL);
+  ck_assert_ptr_eq(tw_minhash_clone(NULL), NULL);
+
+  tw_minhash_add(NULL, NULL, 0);
+  tw_minhash_add(a, NULL, 1);
+  tw_minhash_add(a, &a_size, 0);
+  tw_minhash_add(a, &a_size, 1);
+
+  tw_minhash_estimate(a, b);
+  tw_minhash_estimate(a, NULL);
+  tw_minhash_estimate(NULL, NULL);
+
+  ck_assert(!tw_minhash_equal(a, b));
+  ck_assert(!tw_minhash_equal(NULL, b));
+  ck_assert(!tw_minhash_equal(a, NULL));
+
+  ck_assert_ptr_eq(tw_minhash_merge(a, b), NULL);
+  ck_assert_ptr_eq(tw_minhash_merge(a, NULL), NULL);
+  ck_assert_ptr_eq(tw_minhash_merge(NULL, b), NULL);
+
+  tw_minhash_free(NULL);
+  tw_minhash_free(b);
+  tw_minhash_free(a);
+}
+END_TEST
+
 int run_tests()
 {
   int number_failed;
@@ -150,6 +189,7 @@ int run_tests()
   tcase_add_test(tc, test_minhash_basic);
   tcase_add_test(tc, test_minhash_copy_and_clone);
   tcase_add_test(tc, test_minhash_merge);
+  tcase_add_test(tc, test_minhash_errors);
   /* added for travis slowness of clang */
   tcase_set_timeout(tc, 15);
   suite_add_tcase(s, tc);


### PR DESCRIPTION
Asserts we removed and replaced with proper safe return behaviour instead. Previously, asserts would be removed in Release mode and lead to undefined behaviours (mostly segfaults).

This resolves #35 .