### PR TITLE
Vectorize tw_minhash_add

### DIFF
--- a/src/twiddle/hash/minhash.c
+++ b/src/twiddle/hash/minhash.c
@@ -87,10 +87,9 @@ void tw_minhash_add(struct tw_minhash *hash, const void *key, size_t key_size)
 
   const uint32_t n_registers = hash->n_registers;
 
-#define MINH_ADD_LOOP(simd_t, simd_load, simd_add, simd_max, simd_store, simd_set1) \
-  const size_t vec_elts = sizeof(simd_t)/sizeof(uint32_t);                          \
+#define MINH_ADD_LOOP(simd_t, simd_load, simd_add, simd_max, simd_store, simd_set1, vec_elts) \
   uint32_t ib[vec_elts];                                                            \
-  for(size_t i = 0; i < vec_elts; i++)                                                 \
+  for(size_t i = 0; i < vec_elts; i++)                                              \
     ib[i]  = i * b;                                                                 \
   simd_t acc = simd_add(simd_set1(a), simd_load((simd_t *)ib));		            \
   simd_t inc = simd_set1(vec_elts * b);                                             \
@@ -105,10 +104,10 @@ void tw_minhash_add(struct tw_minhash *hash, const void *key, size_t key_size)
 
 #ifdef USE_AVX2
   MINH_ADD_LOOP( __m256i, _mm256_loadu_si256, _mm256_add_epi32, _mm256_max_epu32, 
-		 _mm256_storeu_si256, _mm256_set1_epi32 )
+		 _mm256_storeu_si256, _mm256_set1_epi32, sizeof(__m256i)/sizeof(uint32_t) )
 #elif defined USE_AVX
   MINH_ADD_LOOP( __m128i, _mm_load_si128, _mm_add_epi32, _mm_max_epu32, 
-		 _mm_store_si128, _mm_set1_epi32 )
+		 _mm_store_si128, _mm_set1_epi32, sizeof(__m128i)/sizeof(uint32_t) )
 #else
   for (size_t i = 0; i < n_registers; ++i) {
     const uint32_t hashed_i = a + i * b;

--- a/src/twiddle/hash/minhash.c
+++ b/src/twiddle/hash/minhash.c
@@ -90,7 +90,7 @@ void tw_minhash_add(struct tw_minhash *hash, const void *key, size_t key_size)
 #define MINH_ADD_LOOP(simd_t, simd_load, simd_add, simd_max, simd_store, simd_set1) \
   const size_t vec_elts = sizeof(simd_t)/sizeof(uint32_t);                          \
   uint32_t ib[vec_elts];                                                            \
-  for(int i = 0; i < vec_elts; i++)                                                 \
+  for(size_t i = 0; i < vec_elts; i++)                                                 \
     ib[i]  = i * b;                                                                 \
   simd_t acc = simd_add(simd_set1(a), simd_load((simd_t *)ib));		            \
   simd_t inc = simd_set1(vec_elts * b);                                             \

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_c_benchmark(bench-bitmap)
 add_c_benchmark(bench-bloomfilter)
+add_c_benchmark(bench-minhash)

--- a/tests/benchmarks/bench-minhash.c
+++ b/tests/benchmarks/bench-minhash.c
@@ -1,0 +1,49 @@
+#include <stdlib.h>
+
+#include <twiddle/hash/minhash.h>
+
+#include "benchmark.h"
+
+
+void minhash_setup(struct benchmark *b)
+{
+
+  b->opaque = (void *) tw_minhash_new(b->size);
+  
+}
+
+void minhash_teardown(struct benchmark *b)
+{
+  tw_minhash_free(b->opaque);
+  b->opaque = NULL;
+}
+
+void minhash_add(void *opaque)
+{
+  struct tw_minhash *h  = (struct tw_minhash *)opaque;
+
+  for( size_t i = 0; i < 10000; i++)
+    tw_minhash_add(h, &i, sizeof(i));
+
+}
+
+int main(int argc, char *argv[])
+{
+
+  if (argc != 3) {
+    fprintf(stderr, "usage: %s <repeat> <size>\n", argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  const size_t repeat = strtol(argv[1], NULL, 10);
+  const size_t size = strtol(argv[2], NULL, 10);
+
+  struct benchmark benchmarks[] = {
+      BENCHMARK_FIXTURE(minhash_add, repeat, size, minhash_setup,
+                        minhash_teardown)
+  };
+
+  run_benchmarks(benchmarks, sizeof(benchmarks) / sizeof(benchmarks[0]));
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This routine spends most of its time calculating

    registers[i] = max( a + b*i, registers[i] )

with a and b from the hash of the id being added.  Vectorizing the above yields about a 5x speedup for that loop, or .2-.4 cycles per i vs. 1.0-1.2 for the scalar code.