### PR TITLE
shorter count loop in minhash estimate

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@
 # packaging, so once an API has stabilized, this should be a rare occurrence.
 #
 # [1] http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html#Updating-version-info
-
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -funroll-loops")
 add_c_library(
     libtwiddle
     OUTPUT_NAME twiddle

--- a/src/twiddle/hash/minhash.c
+++ b/src/twiddle/hash/minhash.c
@@ -73,7 +73,11 @@ struct tw_minhash *tw_minhash_clone(const struct tw_minhash *hash)
   return tw_minhash_copy(hash, copy);
 }
 
+#ifdef __clang__
+#pragma clang loop unroll_count(N)
+#else
 #pragma GCC optimize ("unroll-loops")
+#endif
 
 void tw_minhash_add(struct tw_minhash *hash, const void *key, size_t key_size)
 {

--- a/src/twiddle/hash/minhash.c
+++ b/src/twiddle/hash/minhash.c
@@ -73,6 +73,8 @@ struct tw_minhash *tw_minhash_clone(const struct tw_minhash *hash)
   return tw_minhash_copy(hash, copy);
 }
 
+#pragma GCC optimize ("unroll-loops")
+
 void tw_minhash_add(struct tw_minhash *hash, const void *key, size_t key_size)
 {
   if (!hash || !key || !key_size) {

--- a/src/twiddle/hash/minhash.c
+++ b/src/twiddle/hash/minhash.c
@@ -73,10 +73,6 @@ struct tw_minhash *tw_minhash_clone(const struct tw_minhash *hash)
   return tw_minhash_copy(hash, copy);
 }
 
-#ifndef __clang__
-#pragma GCC optimize ("unroll-loops")
-#endif
-
 void tw_minhash_add(struct tw_minhash *hash, const void *key, size_t key_size)
 {
   if (!hash || !key || !key_size) {

--- a/src/twiddle/hash/minhash.c
+++ b/src/twiddle/hash/minhash.c
@@ -73,9 +73,7 @@ struct tw_minhash *tw_minhash_clone(const struct tw_minhash *hash)
   return tw_minhash_copy(hash, copy);
 }
 
-#ifdef __clang__
-#pragma clang loop unroll_count(4)
-#else
+#ifndef __clang__
 #pragma GCC optimize ("unroll-loops")
 #endif
 

--- a/src/twiddle/hash/minhash.c
+++ b/src/twiddle/hash/minhash.c
@@ -74,7 +74,7 @@ struct tw_minhash *tw_minhash_clone(const struct tw_minhash *hash)
 }
 
 #ifdef __clang__
-#pragma clang loop unroll_count(N)
+#pragma clang loop unroll_count(4)
 #else
 #pragma GCC optimize ("unroll-loops")
 #endif

--- a/tests/benchmarks/bench-minhash.c
+++ b/tests/benchmarks/bench-minhash.c
@@ -27,6 +27,15 @@ void minhash_add(void *opaque)
 
 }
 
+void minhash_est(void *opaque)
+{
+  struct tw_minhash *h  = (struct tw_minhash *)opaque;
+
+  for( size_t i = 0; i < 10000; i++)
+    tw_minhash_estimate(h,h);
+
+}
+
 int main(int argc, char *argv[])
 {
 
@@ -40,6 +49,8 @@ int main(int argc, char *argv[])
 
   struct benchmark benchmarks[] = {
       BENCHMARK_FIXTURE(minhash_add, repeat, size, minhash_setup,
+                        minhash_teardown),
+      BENCHMARK_FIXTURE(minhash_est, repeat, size, minhash_setup,
                         minhash_teardown)
   };
 


### PR DESCRIPTION
This shortens the loop body in minhash estimate to sum mask values vertically and then total horizontally at the end.  

A benchmark was added and shows about 2x improvement over scalar.   