### PR TITLE
Performance tuning on minhash merge, add

### DIFF
--- a/tests/benchmarks/bench-minhash.c
+++ b/tests/benchmarks/bench-minhash.c
@@ -24,6 +24,14 @@ void minhash_add(void *opaque)
     tw_minhash_add(h, &i, sizeof(i));
 }
 
+void minhash_merge(void *opaque)
+{
+  struct tw_minhash *h = (struct tw_minhash *)opaque;
+
+  for (size_t i = 0; i < 10000; i++)
+    tw_minhash_merge(h, h);
+}
+
 void minhash_est(void *opaque)
 {
   struct tw_minhash *h = (struct tw_minhash *)opaque;
@@ -47,6 +55,8 @@ int main(int argc, char *argv[])
       BENCHMARK_FIXTURE(minhash_add, repeat, size, minhash_setup,
                         minhash_teardown),
       BENCHMARK_FIXTURE(minhash_est, repeat, size, minhash_setup,
+                        minhash_teardown),
+      BENCHMARK_FIXTURE(minhash_merge, repeat, size, minhash_setup,
                         minhash_teardown)};
 
   run_benchmarks(benchmarks, sizeof(benchmarks) / sizeof(benchmarks[0]));


### PR DESCRIPTION
Several tuning changes to tw_minhash_merge and other minhash vectorized loops.  

Unrolling 2-4x gives significant speedup.  To make these readable, pointer arithmetic has been reorganized to use array references to simd_t's.  Loop bodies are shorter and don't need load/store symbols.

Removed explicit simd load/store's and saw an unexpected speedup; the compiler may be reordering implicit loads better than explicit ones.

Added AVX512 options for some simd loops (untested).

Added a merge benchmark.

Tests vs. master:  2833 --> 1297 cycles for merge (AVX2).  Add: 2412 --> 1591.  